### PR TITLE
feat: optimizations (some due to Noah's comments)

### DIFF
--- a/bls/src/bls/keys.rs
+++ b/bls/src/bls/keys.rs
@@ -1,17 +1,15 @@
 use crate::curve::hash::HashToG2;
-use algebra::{
-    bytes::{FromBytes, ToBytes},
-    curves::{
-        bls12_377::{
-            Bls12_377, Bls12_377Parameters, G1Affine, G1Projective, G2Affine, G2Projective,
-        },
-        AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve,
+use algebra::{bytes::{FromBytes, ToBytes}, curves::{
+    bls12_377::{
+        Bls12_377, Bls12_377Parameters, g1::Bls12_377G1Parameters, G1Affine, G1Projective, G2Affine, G2Projective,
     },
-    fields::{
-        bls12_377::{Fq12, Fr},
-        Field,
-    },
-};
+    AffineCurve, PairingCurve, PairingEngine, ProjectiveCurve,
+    models::SWModelParameters,
+}, fields::{
+    bls12_377::{Fq12, Fq, Fr},
+    Field,
+    PrimeField,
+}, SquareRootField};
 
 use failure::Error;
 use rand::Rng;
@@ -21,7 +19,7 @@ static POP_DOMAIN: &'static [u8] = b"ULforpop";
 
 /// Implements BLS signatures as specified in https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html.
 use std::{
-    io::{Read, Result as IoResult, Write},
+    io::{self, Read, Result as IoResult, Write},
     ops::{Mul, Neg},
 };
 
@@ -164,14 +162,38 @@ impl PublicKey {
 impl ToBytes for PublicKey {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.pk.into_affine().write(&mut writer)
+        let affine = self.pk.into_affine();
+        let mut x_bytes: Vec<u8> = vec![];
+        let y_big = affine.y.into_repr();
+        let half = Fq::modulus_minus_one_div_two();
+        affine.x.write(&mut x_bytes)?;
+        if y_big >= half {
+            let num_x_bytes = x_bytes.len();
+            x_bytes[num_x_bytes - 1] |= 0x80;
+        }
+        writer.write(&x_bytes)?;
+        Ok(())
     }
 }
 
 impl FromBytes for PublicKey {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let pk = G1Affine::read(&mut reader)?;
+        let mut x_bytes_with_y: Vec<u8> = vec![];
+        reader.read_to_end(&mut x_bytes_with_y)?;
+        let x_bytes_with_y_len = x_bytes_with_y.len();
+        let y_over_half = (x_bytes_with_y[x_bytes_with_y_len - 1] & 0x80) == 0x80;
+        x_bytes_with_y[x_bytes_with_y_len - 1] &= 0xFF - 0x80;
+        let x = Fq::read(x_bytes_with_y.as_slice())?;
+        let x3b = <Bls12_377G1Parameters as SWModelParameters>::add_b(
+            &((x.square() * &x) + &<Bls12_377G1Parameters as SWModelParameters>::mul_by_a(&x)),
+        );
+        let y = x3b.sqrt().ok_or(
+            io::Error::new(io::ErrorKind::NotFound, "couldn't find square root for x")
+        )?;
+        let negy = -y;
+        let chosen_y = if (y < negy) ^ y_over_half { y } else { negy };
+        let pk = G1Affine::new(x, chosen_y, false);
         Ok(PublicKey::from_pk(&pk.into_projective()))
     }
 }
@@ -320,5 +342,19 @@ mod test {
         let message2 = b"goodbye";
         apk.verify(&message2[..], &[], &asig, &try_and_increment)
             .unwrap_err();
+    }
+
+    #[test]
+    fn test_public_key_serialization() {
+        let rng = &mut thread_rng();
+        for _i in 0..100 {
+            let sk = PrivateKey::generate(rng);
+            let pk = sk.to_public();
+            let mut pk_bytes = vec![];
+            pk.write(&mut pk_bytes).unwrap();
+            let pk2 = PublicKey::read(pk_bytes.as_slice()).unwrap();
+            assert_eq!(pk.get_pk().into_affine().x, pk2.get_pk().into_affine().x);
+            assert_eq!(pk.get_pk().into_affine().y, pk2.get_pk().into_affine().y);
+        }
     }
 }

--- a/bls/src/curve/hash/try_and_increment.rs
+++ b/bls/src/curve/hash/try_and_increment.rs
@@ -18,8 +18,10 @@ use algebra::{
         AffineCurve,
     },
     fields::{Field, Fp2, FpParameters, PrimeField, SquareRootField},
+    bytes::FromBytes,
 };
 
+#[allow(dead_code)]
 fn bytes_to_fp<P: Bls12Parameters>(bytes: &[u8]) -> P::Fp {
     let two = {
         let tmp = P::Fp::one();
@@ -76,24 +78,37 @@ fn get_point_from_x<P: Bls12Parameters>(
 }
 impl<'a, H: PRF> HashToG2 for TryAndIncrement<'a, H> {
     fn hash<P: Bls12Parameters>(&self, domain: &[u8], message: &[u8], extra_data: &[u8]) -> Result<G2Projective<P>, Error> {
-        const NUM_TRIES: usize = 10000;
-        const EXTRA_BITS: usize = 135;
-        const EXPECTED_TOTAL_BITS: usize = 1024;
+        const NUM_TRIES: usize = 256;
+        const EXPECTED_TOTAL_BITS: usize = 384*2;
+        const LAST_BYTE_MASK: u8 = 1;
 
-        let fp_bits = <P::Fp as PrimeField>::Params::MODULUS_BITS as usize;
-        let fp_bits_with_extra = fp_bits + EXTRA_BITS;
-        let num_bits = 2 * fp_bits_with_extra; //2*(Fq + EXTRA_BITS), generate 2 field elements with extra bits to reduce modulo bias
+        //round up to a multiple of 8
+        let fp_bits = (((<P::Fp as PrimeField>::Params::MODULUS_BITS as f64)/8.0).ceil() as usize)*8;
+        let num_bits = 2 * fp_bits; //2*(Fq + EXTRA_BITS), generate 2 field elements with extra bits
         assert_eq!(num_bits, EXPECTED_TOTAL_BITS);
         let message_hash = self.hasher.crh(message)?;
         let mut counter: [u8; 1] = [0; 1];
-        for c in 1..NUM_TRIES {
+        for c in 0..NUM_TRIES {
             (&mut counter[..]).write_u8(c as u8)?;
             let hash = self
                 .hasher
                 .prf(domain, &[&counter, extra_data, message_hash.as_slice()].concat(), num_bits)?;
             let possible_x = {
-                let possible_x_0 = bytes_to_fp::<P>(&hash[..hash.len() / 2]);
-                let possible_x_1 = bytes_to_fp::<P>(&hash[hash.len() / 2..]);
+                //zero out the last byte except the first bit, to get to a total of 377 bits
+                let mut possible_x_0_bytes = (&hash[..hash.len()/2]).to_vec();
+                let possible_x_0_bytes_len = possible_x_0_bytes.len();
+                possible_x_0_bytes[possible_x_0_bytes_len - 1] &= LAST_BYTE_MASK;
+                let possible_x_0 = P::Fp::read(possible_x_0_bytes.as_slice())?;
+                if possible_x_0 == P::Fp::zero() {
+                    continue;
+                }
+                let mut possible_x_1_bytes = (&hash[hash.len() / 2..]).to_vec();
+                let possible_x_1_bytes_len = possible_x_1_bytes.len();
+                possible_x_1_bytes[possible_x_1_bytes_len - 1] &= LAST_BYTE_MASK;
+                let possible_x_1 = P::Fp::read(possible_x_1_bytes.as_slice())?;
+                if possible_x_1 == P::Fp::zero() {
+                    continue;
+                }
                 Fp2::<P::Fp2Params>::new(possible_x_0, possible_x_1)
             };
             match get_point_from_x::<P>(possible_x, true) {

--- a/go/bls.go
+++ b/go/bls.go
@@ -187,6 +187,20 @@ func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
 	return aggregatedPublicKey, nil
 }
 
+func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
+	publicKeysPtrs := []*C.struct_PublicKey{}
+	for _, pk := range publicKeys {
+		publicKeysPtrs = append(publicKeysPtrs, pk.ptr)
+	}
+	subtractedPublicKey := &PublicKey{}
+	success := C.aggregate_public_keys_subtract(aggregatedPublicKey.ptr, (**C.struct_PublicKey)(unsafe.Pointer(&publicKeysPtrs[0])), C.int(len(publicKeysPtrs)), &subtractedPublicKey.ptr)
+	if !success {
+		return nil, GeneralError
+	}
+
+	return subtractedPublicKey, nil
+}
+
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
 	signaturesPtrs := []*C.struct_Signature{}
 	for _, pk := range signatures {

--- a/go/bls.h
+++ b/go/bls.h
@@ -28,4 +28,5 @@ void destroy_signature(Signature*);
 bool verify_signature(const PublicKey*, const unsigned char*, int32_t, const unsigned char*, int32_t, const Signature*, bool, bool*);
 bool verify_pop(const PublicKey*, const Signature*, bool*);
 bool aggregate_public_keys(const PublicKey**, int32_t, PublicKey**);
+bool aggregate_public_keys_subtract(const PublicKey*, const PublicKey**, int32_t, PublicKey**);
 bool aggregate_signatures(const Signature**, int32_t, Signature**);

--- a/go/bls_test.go
+++ b/go/bls_test.go
@@ -37,6 +37,11 @@ func TestAggregatedSig(t *testing.T) {
 		t.Fatalf("succeeded verifying signature for wrong pk, shouldn't have!")
 	}
 
+	subtractedPublicKey, _ := AggregatePublicKeysSubtract(aggergatedPublicKey, []*PublicKey{publicKey2})
+	err = subtractedPublicKey.VerifySignature(message, extraData, signature, true)
+	if err != nil {
+		t.Fatalf("failed verifying signature for subtractedPublicKey pk, error was: %s", err)
+	}
 }
 
 func TestProofOfPossession(t *testing.T) {


### PR DESCRIPTION
### Description

* Public keys are stored compressed, with the last bit signifying
whether y is the greatest of the two options.
* Try-and-increment now generates enough random bits so each attempt to
generate field elements or group elements should succeed in expected 2
tries and rejects invalid results. This lets us use one less prf
execution.
* Aggregation with subtraction is exposed.

### Tested

* Unit tests pass.
* Added a new test for compressed public keys.