### PR TITLE
fix: removes unneeded print of pk in pop

### DIFF
--- a/bls/examples/pop.rs
+++ b/bls/examples/pop.rs
@@ -32,9 +32,11 @@ fn main() {
     pop.write(&mut pop_bytes).unwrap();
 
     let pk = sk.to_public();
+    /*
     let mut pk_bytes = vec![];
     pk.write(&mut pk_bytes).unwrap();
     println!("{}", hex::encode(&pk_bytes));
+    */
 
     pk.verify_pop(&pop, &try_and_increment).unwrap();
 


### PR DESCRIPTION
### Description

Mistakenly added a pk print in the pop, which causes tests to fail.