### PR TITLE
fix: makes android build compatible with geth

### DIFF
--- a/go/bls_android.go
+++ b/go/bls_android.go
@@ -1,9 +1,8 @@
-// +build !linux,!darwin,android
-// +build arm
+// +build android
 
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/armv7-linux-androideabi/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/x86_64-linux-android/release -L../bls/target/i686-linux-android/release -L../bls/target/armv7-linux-androideabi/release -L../bls/target/aarch64-linux-android/release -lbls_zexe -ldl -lm
 */
 import "C"

--- a/go/bls_android_64.go
+++ b/go/bls_android_64.go
@@ -1,9 +1,0 @@
-// +build !linux,!darwin,android
-// +build arm64
-
-package bls
-
-/*
-#cgo LDFLAGS: -L../bls/target/aarch64-linux-android/release -lbls_zexe -ldl -lm
-*/
-import "C"


### PR DESCRIPTION
### Description

Geth expects an android target go file, which currently is too fine-grained.