### PR TITLE
Switch signature from G2 to G1

### DIFF
--- a/bls/algebra/examples/pop_csv.rs
+++ b/bls/algebra/examples/pop_csv.rs
@@ -42,16 +42,17 @@ fn main() {
     for _ in 0..num {
         let sk = PrivateKey::generate(rng);
         let pk = sk.to_public();
+        let address_bytes = hex::decode("60515f8c59451e04ab4b22b3fc9a196b2ad354e6").unwrap();
         let mut pk_bytes = vec![];
         pk.write(&mut pk_bytes).unwrap();
-        let pop = sk.sign_pop(&pk_bytes, &try_and_increment).unwrap();
+        let pop = sk.sign_pop(&address_bytes, &try_and_increment).unwrap();
         let mut pop_bytes = vec![];
         pop.write(&mut pop_bytes).unwrap();
 
         let mut sk_bytes = vec![];
         sk.write(&mut sk_bytes).unwrap();
 
-        pk.verify_pop(&pk_bytes, &pop, &try_and_increment).unwrap();
+        pk.verify_pop(&address_bytes, &pop, &try_and_increment).unwrap();
 
         file.write_all(format!("{},{},{}\n", hex::encode(sk_bytes), hex::encode(pk_bytes), hex::encode(pop_bytes)).as_bytes()).unwrap();
     }

--- a/bls/algebra/src/curve/cofactor.rs
+++ b/bls/algebra/src/curve/cofactor.rs
@@ -4,7 +4,7 @@ use algebra::{
     biginteger::BigInteger,
     curves::{
         models::{
-            bls12::{Bls12Parameters, G2Affine, G2Projective},
+            bls12::{Bls12Parameters, G2Affine, G1Projective, G2Projective},
             ModelParameters,
         },
         AffineCurve, ProjectiveCurve,
@@ -127,6 +127,10 @@ pub fn scale_by_cofactor_fuentes<P: Bls12Parameters>(p: &G2Projective<P>) -> G2P
     let p5 = p.double(); //2
 
     p4 + &psi::<P>(&p2, 1) + &psi::<P>(&p5, 2)
+}
+
+pub fn scale_by_cofactor_g1<P: Bls12Parameters>(p: &G1Projective<P>) -> G1Projective<P> {
+    p.into_affine().scale_by_cofactor()
 }
 
 #[cfg(test)]

--- a/bls/algebra/src/curve/hash/mod.rs
+++ b/bls/algebra/src/curve/hash/mod.rs
@@ -1,6 +1,6 @@
 pub mod try_and_increment;
 
-use algebra::curves::models::bls12::{Bls12Parameters, G2Projective};
+use algebra::curves::models::bls12::{Bls12Parameters, G1Projective, G2Projective};
 use std::{
     fmt::{self, Display},
     error::Error,
@@ -25,4 +25,8 @@ impl Error for HashToCurveError {
 
 pub trait HashToG2 {
     fn hash<P: Bls12Parameters>(&self, domain: &[u8], message: &[u8], extra_data: &[u8]) -> Result<G2Projective<P>, Box<dyn Error>>;
+}
+
+pub trait HashToG1 {
+    fn hash<P: Bls12Parameters>(&self, domain: &[u8], message: &[u8], extra_data: &[u8]) -> Result<G1Projective<P>, Box<dyn Error>>;
 }

--- a/bls/algebra/src/curve/hash/try_and_increment.rs
+++ b/bls/algebra/src/curve/hash/try_and_increment.rs
@@ -1,7 +1,7 @@
 use crate::{
     curve::{
         cofactor,
-        hash::{HashToCurveError, HashToG2},
+        hash::{HashToCurveError, HashToG1, HashToG2},
     },
     hash::XOF,
 };
@@ -11,7 +11,7 @@ use hex;
 use algebra::{
     curves::{
         models::{
-            bls12::{Bls12Parameters, G2Affine, G2Projective},
+            bls12::{Bls12Parameters, G1Affine, G2Affine, G1Projective, G2Projective},
             ModelParameters, SWModelParameters,
         },
         AffineCurve,
@@ -48,7 +48,7 @@ fn bytes_to_fp<P: Bls12Parameters>(bytes: &[u8]) -> P::Fp {
     element
 }
 
-/// A try-and-increment method for hashing to G2. See page 521 in
+/// A try-and-increment method for hashing to G1 and G2. See page 521 in
 /// https://link.springer.com/content/pdf/10.1007/3-540-45682-1_30.pdf.
 pub struct TryAndIncrement<'a, H: XOF> {
     hasher: &'a H,
@@ -58,6 +58,23 @@ impl<'a, H: XOF> TryAndIncrement<'a, H> {
     pub fn new(h: &'a H) -> Self {
         TryAndIncrement::<H> { hasher: h }
     }
+}
+
+fn get_point_from_x_g1<P: Bls12Parameters>(
+    x: <P::G1Parameters as ModelParameters>::BaseField,
+    greatest: bool,
+) -> Option<G1Affine<P>> {
+    // Compute x^3 + ax + b
+    let x3b = <P::G1Parameters as SWModelParameters>::add_b(
+        &((x.square() * &x) + &<P::G1Parameters as SWModelParameters>::mul_by_a(&x)),
+    );
+
+    x3b.sqrt().map(|y| {
+        let negy = -y;
+
+        let y = if (y < negy) ^ greatest { y } else { negy };
+        G1Affine::<P>::new(x, y, false)
+    })
 }
 
 fn get_point_from_x<P: Bls12Parameters>(
@@ -76,6 +93,57 @@ fn get_point_from_x<P: Bls12Parameters>(
         G2Affine::<P>::new(x, y, false)
     })
 }
+impl<'a, H: XOF> HashToG1 for TryAndIncrement<'a, H> {
+    fn hash<P: Bls12Parameters>(&self, domain: &[u8], message: &[u8], extra_data: &[u8]) -> Result<G1Projective<P>, Box<dyn Error>> {
+        const NUM_TRIES: usize = 256;
+        const EXPECTED_TOTAL_BITS: usize = 384;
+        const LAST_BYTE_MASK: u8 = 1;
+        const GREATEST_MASK: u8 = 2;
+
+        //round up to a multiple of 8
+        let fp_bits = (((<P::Fp as PrimeField>::Params::MODULUS_BITS as f64)/8.0).ceil() as usize)*8;
+        let num_bits = fp_bits;
+        assert_eq!(num_bits, EXPECTED_TOTAL_BITS);
+        let num_bytes = num_bits / 8;
+        let mut counter: [u8; 1] = [0; 1];
+        let hash_loop_time = start_timer!(|| "try_and_increment::hash_loop");
+        for c in 0..NUM_TRIES {
+            (&mut counter[..]).write_u8(c as u8)?;
+            let hash = self
+                .hasher
+                .hash(domain, &[&counter, extra_data, &message].concat(), num_bytes)?;
+            let (possible_x, greatest) = {
+                //zero out the last byte except the first bit, to get to a total of 377 bits
+                let mut possible_x_bytes = hash.to_vec();
+                let possible_x_bytes_len = possible_x_bytes.len();
+                possible_x_bytes[possible_x_bytes_len - 1] &= LAST_BYTE_MASK;
+                let possible_x = P::Fp::read(possible_x_bytes.as_slice())?;
+                if possible_x == P::Fp::zero() {
+                    continue;
+                }
+                let greatest = (possible_x_bytes[possible_x_bytes_len - 1] & GREATEST_MASK) == GREATEST_MASK;
+
+                (possible_x, greatest)
+            };
+            match get_point_from_x_g1::<P>(possible_x, greatest) {
+                None => continue,
+                Some(x) => {
+                    debug!(
+                        "succeeded hashing \"{}\" to G2 in {} tries",
+                        hex::encode(message),
+                        c
+                    );
+                    end_timer!(hash_loop_time);
+                    return Ok(cofactor::scale_by_cofactor_g1::<P>(
+                        &x.into_projective(),
+                    ));
+                }
+            }
+        }
+        Err(HashToCurveError::CannotFindPoint)?
+    }
+}
+
 impl<'a, H: XOF> HashToG2 for TryAndIncrement<'a, H> {
     fn hash<P: Bls12Parameters>(&self, domain: &[u8], message: &[u8], extra_data: &[u8]) -> Result<G2Projective<P>, Box<dyn Error>> {
         const NUM_TRIES: usize = 256;

--- a/bls/algebra/src/hash/direct.rs
+++ b/bls/algebra/src/hash/direct.rs
@@ -16,10 +16,10 @@ impl DirectHasher {
 
 }
 
-fn xof_digest_length_to_node_offset(node_offset: usize, xof_digest_length: usize) -> Result<u64, Box<dyn Error>> {
+fn xof_digest_length_to_node_offset(node_offset: u64, xof_digest_length: usize) -> Result<u64, Box<dyn Error>> {
     let mut xof_digest_length_bytes: [u8; 2] = [0; 2];
     (&mut xof_digest_length_bytes[..]).write_u16::<LittleEndian>(xof_digest_length as u16)?;
-    let offset = (node_offset | ((xof_digest_length_bytes[0] as usize) << 32) | ((xof_digest_length_bytes[1] as usize) << 40)) as u64;
+    let offset = node_offset as u64 | ((xof_digest_length_bytes[0] as u64) << 32) | ((xof_digest_length_bytes[1] as u64) << 40);
     Ok(offset)
 }
 
@@ -53,7 +53,7 @@ impl XOF for DirectHasher {
                 .fanout(0)
                 .max_depth(0)
                 .personal(domain)
-                .node_offset(xof_digest_length_to_node_offset(i, xof_digest_length)?)
+                .node_offset(xof_digest_length_to_node_offset(i as u64, xof_digest_length)?)
                 .to_state()
                 .update(hashed_message)
                 .finalize()

--- a/bls/snark/Cargo.toml
+++ b/bls/snark/Cargo.toml
@@ -8,7 +8,11 @@ edition = "2018"
 r1cs-std = { path = "../../zexe/r1cs-std" }
 r1cs-core = { path = "../../zexe/r1cs-core" }
 algebra = { path = "../../zexe/algebra" }
+bls-zexe = { path = "../algebra" }
 rand = { version = "0.7" }
+byteorder = "1.3.2"
+hex = "0.3.2"
+log = "0.4.6"
 
 [dev-dependencies]
 rand_xorshift = { version = "0.2" }

--- a/bls/snark/src/encoding/mod.rs
+++ b/bls/snark/src/encoding/mod.rs
@@ -1,0 +1,168 @@
+use algebra::{
+    fields::{
+        FpParameters,
+        PrimeField,
+        bls12_377::{
+            Fq,
+            FqParameters,
+        },
+    },
+    curves::ProjectiveCurve,
+    bytes::ToBytes,
+};
+use byteorder::{LittleEndian, WriteBytesExt};
+use bls_zexe::bls::keys::PublicKey;
+use std::error::Error;
+
+/// If bytes is a little endian representation of a number, this would return the bits of the
+/// number in descending order
+pub fn bytes_to_bits(bytes: &Vec<u8>, bits_to_take: usize) -> Vec<bool> {
+    let mut bits = vec![];
+    for i in 0..bytes.len() {
+        let mut byte = bytes[i];
+        for _ in 0..8 {
+            bits.push((byte & 1) == 1);
+            byte >>= 1;
+        }
+    }
+
+    let bits_filtered = bits.into_iter().take(bits_to_take).collect::<Vec<bool>>().into_iter().rev().collect();
+
+    bits_filtered
+}
+
+pub fn bits_to_bytes(bits: &Vec<bool>) -> Vec<u8> {
+    let mut bytes = vec![];
+    let reversed_bits = {
+        let mut tmp = bits.clone();
+        tmp.reverse();
+        tmp
+    };
+    for chunk in reversed_bits.chunks(8) {
+        let mut byte = 0;
+        let mut twoi = 1;
+        for i in 0..chunk.len() {
+            byte += twoi*(if chunk[i] { 1 } else { 0 });
+            twoi *= 2;
+        }
+        bytes.push(byte);
+    }
+
+    bytes
+}
+
+/// The function assumes that the public key is not the point in infinity, which is true for
+/// BLS public keys
+pub fn encode_public_key(public_key: &PublicKey) -> Result<Vec<bool>, Box<dyn Error>> {
+    let pk_affine = public_key.get_pk().into_affine();
+    let x = pk_affine.x;
+    let y = pk_affine.y;
+
+    let y_c0_big = y.c0.into_repr();
+    let y_c1_big = y.c1.into_repr();
+
+    let half = Fq::modulus_minus_one_div_two();
+    let is_over_half = if y_c1_big > half {
+        true
+    } else if y_c1_big == half && y_c0_big > half {
+        true
+    } else {
+        false
+    };
+
+    let mut x_bytes = vec![];
+    x.write(&mut x_bytes)?;
+    let mut bits = bytes_to_bits(&x_bytes, FqParameters::MODULUS_BITS as usize);
+    bits.push(is_over_half);
+
+    Ok(bits)
+}
+
+pub fn encode_zero_value_public_key() -> Result<Vec<bool>, Box<dyn Error>> {
+    // x coordinate and a y bit
+    Ok(std::iter::repeat(false).take(Fq::size_in_bits() + 1).collect::<Vec<_>>())
+}
+
+pub fn encode_u16(num: u16) -> Result<Vec<bool>, Box<dyn Error>> {
+    let mut bytes = vec![];
+    bytes.write_u16::<LittleEndian>(num)?;
+    let bits = bytes.into_iter().map(|x| (0..8).map(move |i| {
+        (((x as u16) & u16::pow(2, i)) >> i) == 1
+    })).flatten().collect::<Vec<_>>();
+    Ok(bits)
+}
+
+pub fn encode_u32(num: u32) -> Result<Vec<bool>, Box<dyn Error>> {
+    let mut bytes = vec![];
+    bytes.write_u32::<LittleEndian>(num)?;
+    let bits = bytes.into_iter().map(|x| (0..8).map(move |i| {
+        (((x as u32) & u32::pow(2, i)) >> i) == 1
+    })).flatten().collect::<Vec<_>>();
+    Ok(bits)
+}
+
+/// The goal of the validator diff encoding is to be a constant-size encoding so it would be
+/// more easily processable in SNARKs
+pub fn encode_epoch_block_to_bits(epoch_index: u16, maximum_non_signers: u32, aggregated_public_key: &PublicKey, new_public_keys: &Vec<&PublicKey>) -> Result<Vec<bool>, Box<dyn Error>> {
+    let mut epoch_bits = vec![];
+
+    epoch_bits.extend_from_slice(&encode_u16(epoch_index)?);
+    epoch_bits.extend_from_slice(&encode_u32(maximum_non_signers)?);
+    epoch_bits.extend_from_slice(encode_public_key(&aggregated_public_key)?.as_slice());
+    for added_public_key in new_public_keys {
+        epoch_bits.extend_from_slice(encode_public_key(&added_public_key)?.as_slice());
+    }
+    Ok(epoch_bits)
+}
+
+pub fn encode_epoch_block_to_bytes(epoch_index: u16, maximum_non_signers: u32, aggregated_public_key: &PublicKey, added_public_keys: &Vec<&PublicKey>) -> Result<Vec<u8>, Box<dyn Error>> {
+    Ok(bits_to_bytes(&encode_epoch_block_to_bits(epoch_index, maximum_non_signers, aggregated_public_key, added_public_keys)?))
+}
+
+#[cfg(test)]
+mod test {
+    use byteorder::{LittleEndian, WriteBytesExt};
+    use rand::{Rng, SeedableRng};
+    use crate::encoding::{bytes_to_bits, bits_to_bytes};
+    use rand_xorshift::XorShiftRng;
+    use algebra::fields::{
+        FpParameters,
+        bls12_377::FqParameters,
+    };
+
+    #[test]
+    fn test_bytes_to_bits() {
+        let mut rng = XorShiftRng::from_seed([0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06, 0x54]);
+        for _ in 0..100 {
+            let n = rng.gen();
+            let mut bytes = vec![];
+            bytes.write_u64::<LittleEndian>(n).unwrap();
+
+            let bits = bytes_to_bits(&bytes, FqParameters::MODULUS_BITS as usize);
+            let mut twoi = 1;
+            let mut result: u64 = 0;
+            let bits_len = bits.len();
+            for i in 0..bits_len {
+                result += twoi * (if bits[bits_len - 1 - i] { 1 } else { 0 });
+                twoi *= 2;
+            }
+
+            assert_eq!(result, n)
+        }
+    }
+
+    #[test]
+    fn test_bits_to_bytes() {
+        let mut rng = XorShiftRng::from_seed([0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06, 0x54]);
+        for _ in 0..100 {
+            let n = rng.gen();
+            let mut bytes = vec![];
+            bytes.write_u64::<LittleEndian>(n).unwrap();
+
+            let bits = bytes_to_bits(&bytes, FqParameters::MODULUS_BITS as usize);
+            let result_bytes = bits_to_bytes(&bits);
+
+            assert_eq!(bytes, result_bytes);
+        }
+    }
+}

--- a/bls/snark/src/lib.rs
+++ b/bls/snark/src/lib.rs
@@ -1,1 +1,60 @@
+pub mod encoding;
 pub mod gadgets;
+
+#[macro_use]
+extern crate log;
+
+use bls_zexe::bls::keys::PublicKey;
+
+use std::{
+    os::raw::{c_ushort, c_uint, c_int},
+    slice,
+    fmt::Display,
+    error::Error,
+};
+
+fn convert_result_to_bool<T, E: Display, F: Fn() -> Result<T, E>>(f: F) -> bool {
+    match f() {
+        Err(e) => {
+            error!("SNARK library error: {}", e.to_string());
+            false
+        }
+        _ => true,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn encode_epoch_block_to_bytes(
+    in_epoch_index: c_ushort,
+    in_maximum_non_signers: c_uint,
+    in_aggregated_public_key: *const PublicKey,
+    in_added_public_keys: *const *const PublicKey,
+    in_added_public_keys_len: c_int,
+    out_bytes: *mut *mut u8,
+    out_len: *mut c_int,
+) -> bool {
+    convert_result_to_bool::<_, Box<dyn Error>, _>(|| {
+        let aggregated_public_key = unsafe { &*in_aggregated_public_key };
+        let added_public_keys_ptrs =
+            unsafe { slice::from_raw_parts(in_added_public_keys, in_added_public_keys_len as usize) };
+        let added_public_keys = added_public_keys_ptrs
+            .to_vec()
+            .into_iter()
+            .map(|pk| unsafe { &*pk })
+            .collect::<Vec<&PublicKey>>();
+
+        let mut encoded = encoding::encode_epoch_block_to_bytes(
+            in_epoch_index as u16,
+            in_maximum_non_signers as u32,
+            &aggregated_public_key,
+            &added_public_keys,
+        )?;
+        encoded.shrink_to_fit();
+        unsafe {
+            *out_bytes = encoded.as_mut_ptr();
+            *out_len = encoded.len() as c_int;
+        }
+        std::mem::forget(encoded);
+        Ok(())
+    })
+}

--- a/go/bls.go
+++ b/go/bls.go
@@ -278,3 +278,19 @@ func AggregateSignatures(signatures []*Signature) (*Signature, error) {
 
 	return aggregatedSignature, nil
 }
+
+func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, aggregatedPublicKey *PublicKey, addedPublicKeys []*PublicKey) ([]byte, error) {
+	publicKeysPtrs := []*C.struct_PublicKey{}
+	for _, pk := range addedPublicKeys {
+		publicKeysPtrs = append(publicKeysPtrs, pk.ptr)
+	}
+	var bytes *C.uchar
+	var size C.int
+	success := C.encode_epoch_block_to_bytes(C.ushort(epochIndex), C.uint(maximumNonSigners), aggregatedPublicKey.ptr, (**C.struct_PublicKey)(unsafe.Pointer(&publicKeysPtrs[0])), C.int(len(publicKeysPtrs)), &bytes, &size)
+	if !success {
+		return nil, GeneralError
+	}
+	defer C.free_vec(bytes, size)
+
+	return C.GoBytes(unsafe.Pointer(bytes), size), nil
+}

--- a/go/bls.go
+++ b/go/bls.go
@@ -14,8 +14,8 @@ const MODULUS377 = "844446174942837042424882493878154653137589933515406382793523
 const MODULUSBITS = 253
 const MODULUSMASK = 31 // == 2**(253-(256-8)) - 1
 const PRIVATEKEYBYTES = 32
-const PUBLICKEYBYTES = 48
-const SIGNATUREBYTES = 96
+const PUBLICKEYBYTES = 96
+const SIGNATUREBYTES = 48
 
 var GeneralError = errors.New("General error")
 var NotVerifiedError = errors.New("Not verified")

--- a/go/bls.h
+++ b/go/bls.h
@@ -30,3 +30,5 @@ bool verify_pop(const PublicKey*, const unsigned char*, int32_t, const Signature
 bool aggregate_public_keys(const PublicKey**, int32_t, PublicKey**);
 bool aggregate_public_keys_subtract(const PublicKey*, const PublicKey**, int32_t, PublicKey**);
 bool aggregate_signatures(const Signature**, int32_t, Signature**);
+
+bool encode_epoch_block_to_bytes(uint16_t, uint32_t, const PublicKey*, const PublicKey**, int32_t, unsigned char**, int32_t*);

--- a/go/bls_android.go
+++ b/go/bls_android.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/x86_64-linux-android/release -L../bls/target/i686-linux-android/release -L../bls/target/armv7-linux-androideabi/release -L../bls/target/aarch64-linux-android/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/x86_64-linux-android/release -L../bls/target/i686-linux-android/release -L../bls/target/armv7-linux-androideabi/release -L../bls/target/aarch64-linux-android/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_arm.go
+++ b/go/bls_arm.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/arm-unknown-linux-gnueabi/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/arm-unknown-linux-gnueabi/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_arm64.go
+++ b/go/bls_arm64.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/aarch64-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/aarch64-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_arm7.go
+++ b/go/bls_arm7.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/arm-unknown-linux-gnueabihf/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/arm-unknown-linux-gnueabihf/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_darwin.go
+++ b/go/bls_darwin.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/i686-apple-darwin/release -L../bls/target/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/i686-apple-darwin/release -L../bls/target/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_darwin64.go
+++ b/go/bls_darwin64.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/x86_64-apple-darwin/release -L../bls/target/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/x86_64-apple-darwin/release -L../bls/target/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_linux.go
+++ b/go/bls_linux.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_linux386.go
+++ b/go/bls_linux386.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/i686-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/i686-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_linux64.go
+++ b/go/bls_linux64.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/x86_64-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/x86_64-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_mips.go
+++ b/go/bls_mips.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/mips-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/mips-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_mips64.go
+++ b/go/bls_mips64.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/mips64-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/mips64-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_mips64le.go
+++ b/go/bls_mips64le.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/mips64el-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/mips64el-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_mipsle.go
+++ b/go/bls_mipsle.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/mipsel-unknown-linux-gnu/release -lbls_zexe -ldl -lm
+#cgo LDFLAGS: -L../bls/target/mipsel-unknown-linux-gnu/release -lbls_zexe -lbls_snark -ldl -lm
 */
 import "C"

--- a/go/bls_test.go
+++ b/go/bls_test.go
@@ -2,6 +2,7 @@ package bls
 
 import (
 	"testing"
+  "encoding/hex"
 )
 
 func TestAggregatedSig(t *testing.T) {
@@ -99,5 +100,23 @@ func TestNonCompositeSig(t *testing.T) {
 	if err == nil {
 		t.Fatalf("succeeded verifying signature for wrong pk, shouldn't have!")
 	}
+}
 
+func TestEncoding(t *testing.T) {
+	InitBLSCrypto()
+	privateKey, _ := GeneratePrivateKey()
+	defer privateKey.Destroy()
+	publicKey, _ := privateKey.ToPublic()
+
+	privateKey2, _ := GeneratePrivateKey()
+	defer privateKey2.Destroy()
+	publicKey2, _ := privateKey2.ToPublic()
+
+	aggergatedPublicKey, _ := AggregatePublicKeys([]*PublicKey{publicKey, publicKey2})
+
+  bytes, err := EncodeEpochToBytes(10, 20, aggergatedPublicKey, []*PublicKey{publicKey, publicKey2})
+	if err != nil {
+		t.Fatalf("failed encoding epoch bytes")
+	}
+  t.Logf("encoding: %s\n", hex.EncodeToString(bytes))
 }

--- a/go/bls_windows.go
+++ b/go/bls_windows.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/i686-pc-windows-gnu/release -lbls_zexe -lm -lws2_32 -luserenv -lunwind
+#cgo LDFLAGS: -L../bls/target/i686-pc-windows-gnu/release -lbls_zexe -lbls_snark -lm -lws2_32 -luserenv -lunwind
 */
 import "C"

--- a/go/bls_windows64.go
+++ b/go/bls_windows64.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L../bls/target/x86_64-pc-windows-gnu/release -lbls_zexe -lm -lws2_32 -luserenv -lunwind
+#cgo LDFLAGS: -L../bls/target/x86_64-pc-windows-gnu/release -lbls_zexe -lbls_snark -lm -lws2_32 -luserenv -lunwind
 */
 import "C"


### PR DESCRIPTION
### Description

* Moves signatures to G1, public keys to G2

### Other changes

* Adds epoch SNARK encoding.
### Related issues

- Fixes #83 
- Fixes #84 

