### PR TITLE
Fix go.mod

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/celo-org/bls-zexe
+module github.com/celo-org/bls-zexe/go
 
 go 1.12


### PR DESCRIPTION
### Description

The correct path needs a trailing `go`