### PR TITLE
Refactor Gadgets to Standalone crate

### DIFF
--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 
-members = [ "algebra", "snark"]
+members = [ 
+    "algebra", 
+    "snark",
+    "gadgets",
+]
 
 [profile.release]
 opt-level = 3

--- a/bls/gadgets/Cargo.toml
+++ b/bls/gadgets/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gadgets"
+version = "0.1.0"
+authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+edition = "2018"
+
+[dependencies]
+bls-zexe = { path = "../algebra" }
+
+algebra = { git = "https://github.com/scipr-lab/zexe", default-features = false, features = ["bls12_377", "sw6", "edwards_sw6", "edwards_bls12"] }
+r1cs-core = { git = "https://github.com/scipr-lab/zexe", default-features = false }
+r1cs-std = { git = "https://github.com/scipr-lab/zexe", default-features = false, features = ["bls12_377", "edwards_sw6", "edwards_bls12"] }
+
+[dev-dependencies]
+rand_xorshift = { version = "0.2" }
+rand = "0.7" 

--- a/bls/gadgets/README.md
+++ b/bls/gadgets/README.md
@@ -1,0 +1,8 @@
+# Gadgets
+
+Zexe R1CS gadgets for doing various useful operations
+
+- BLS Signatures
+- Point Compression
+- Hash to Group
+- Bitmap 0 counter

--- a/bls/gadgets/src/bitmap.rs
+++ b/bls/gadgets/src/bitmap.rs
@@ -61,13 +61,10 @@ pub fn enforce_maximum_zeros_in_bitmap<F: PrimeField, CS: ConstraintSystem<F>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use r1cs_std::test_constraint_system::TestConstraintSystem;
     use algebra::bls12_377::Fq;
+    use r1cs_std::test_constraint_system::TestConstraintSystem;
 
-    fn cs_enforce(
-        bitmap: &[bool],
-        max_zeros: u64,
-    ) -> TestConstraintSystem<Fq> {
+    fn cs_enforce(bitmap: &[bool], max_zeros: u64) -> TestConstraintSystem<Fq> {
         let mut cs = TestConstraintSystem::<Fq>::new();
         let bitmap = bitmap
             .into_iter()
@@ -96,5 +93,4 @@ mod tests {
     fn four_zeros_not_allowed() {
         assert!(!cs_enforce(&[false, false, true, false, false], 3).is_satisfied());
     }
-
 }

--- a/bls/gadgets/src/bitmap.rs
+++ b/bls/gadgets/src/bitmap.rs
@@ -1,5 +1,3 @@
-pub mod bls;
-
 use algebra::PrimeField;
 use r1cs_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use r1cs_std::{

--- a/bls/gadgets/src/bls.rs
+++ b/bls/gadgets/src/bls.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements BLS Verification as written in [BDN18](https://eprint.iacr.org/2018/483.pdf)
 //! in a Pairing-based SNARK.
-use crate::gadgets::enforce_maximum_zeros_in_bitmap;
+use crate::enforce_maximum_zeros_in_bitmap;
 use algebra::{PairingEngine, PrimeField, ProjectiveCurve};
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use r1cs_std::{

--- a/bls/gadgets/src/bls.rs
+++ b/bls/gadgets/src/bls.rs
@@ -7,7 +7,7 @@ use r1cs_std::{
 };
 use std::marker::PhantomData;
 
-/// # BLS Signature Verification Pairing Gadget.
+/// BLS Signature Verification Pairing Gadget.
 ///
 /// Implements BLS Verification as written in [BDN18](https://eprint.iacr.org/2018/483.pdf)
 /// in a Pairing-based SNARK.

--- a/bls/gadgets/src/bls.rs
+++ b/bls/gadgets/src/bls.rs
@@ -1,7 +1,3 @@
-//! # BLS Signature Verification Pairing Gadget.
-//!
-//! Implements BLS Verification as written in [BDN18](https://eprint.iacr.org/2018/483.pdf)
-//! in a Pairing-based SNARK.
 use crate::enforce_maximum_zeros_in_bitmap;
 use algebra::{PairingEngine, PrimeField, ProjectiveCurve};
 use r1cs_core::{ConstraintSystem, SynthesisError};
@@ -11,7 +7,10 @@ use r1cs_std::{
 };
 use std::marker::PhantomData;
 
-/// Gadget for BLS Signature Verification. Must specify the Pairing Engine, Constraint Field
+/// # BLS Signature Verification Pairing Gadget.
+///
+/// Implements BLS Verification as written in [BDN18](https://eprint.iacr.org/2018/483.pdf)
+/// in a Pairing-based SNARK.
 pub struct BlsVerifyGadget<E, F, P> {
     /// The curve being used
     pairing_engine_type: PhantomData<E>,

--- a/bls/gadgets/src/lib.rs
+++ b/bls/gadgets/src/lib.rs
@@ -1,0 +1,10 @@
+//! # Gadgets
+
+mod bls;
+pub use bls::BlsVerifyGadget;
+
+mod bitmap;
+pub use bitmap::enforce_maximum_zeros_in_bitmap;
+
+mod y_to_bit;
+pub use y_to_bit::YToBitGadget;

--- a/bls/gadgets/src/y_to_bit.rs
+++ b/bls/gadgets/src/y_to_bit.rs
@@ -1,0 +1,290 @@
+use algebra::{curves::bls12::Bls12Parameters, One, PrimeField};
+use r1cs_core::SynthesisError;
+use r1cs_std::{
+    alloc::AllocGadget,
+    bits::ToBitsGadget,
+    boolean::Boolean,
+    fields::{fp::FpGadget, FieldGadget},
+    groups::curves::short_weierstrass::bls12::{G1Gadget, G2Gadget},
+    Assignment,
+};
+use std::{marker::PhantomData, ops::Neg};
+
+/// Enforces point compression on the provided element
+pub struct YToBitGadget<P: Bls12Parameters> {
+    parameters_type: PhantomData<P>,
+}
+
+impl<P: Bls12Parameters> YToBitGadget<P> {
+    pub fn y_to_bit_g1<CS: r1cs_core::ConstraintSystem<P::Fp>>(
+        mut cs: CS,
+        pk: &G1Gadget<P>,
+    ) -> Result<Boolean, SynthesisError> {
+        let half_plus_one_neg =
+            (P::Fp::from_repr(P::Fp::modulus_minus_one_div_two()) + &P::Fp::one()).neg();
+        let y_bit = Boolean::alloc(cs.ns(|| "alloc y bit"), || {
+            if pk.y.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                Ok(pk.y.get_value().get()?.into_repr() > half)
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_adjusted = FpGadget::alloc(cs.ns(|| "alloc y"), || {
+            if pk.y.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                let y_value = pk.y.get_value().get()?;
+                if y_value.into_repr() > half {
+                    Ok(y_value - &(P::Fp::from_repr(half) + &P::Fp::one()))
+                } else {
+                    Ok(y_value)
+                }
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_bit_lc = y_bit.lc(CS::one(), half_plus_one_neg);
+        cs.enforce(
+            || "check y bit",
+            |lc| lc + (P::Fp::one(), CS::one()),
+            |lc| pk.y.get_variable() + y_bit_lc + lc,
+            |lc| y_adjusted.get_variable() + lc,
+        );
+        let y_adjusted_bits = &y_adjusted.to_bits(cs.ns(|| "y adjusted to bits"))?;
+        Boolean::enforce_smaller_or_equal_than::<_, _, P::Fp, _>(
+            cs.ns(|| "enforce smaller than modulus minus one div two"),
+            y_adjusted_bits,
+            P::Fp::modulus_minus_one_div_two(),
+        )?;
+        Ok(y_bit)
+    }
+
+    pub fn y_to_bit_g2<CS: r1cs_core::ConstraintSystem<P::Fp>>(
+        mut cs: CS,
+        pk: &G2Gadget<P>,
+    ) -> Result<Boolean, SynthesisError> {
+        let half_plus_one_neg =
+            (P::Fp::from_repr(P::Fp::modulus_minus_one_div_two()) + &P::Fp::one()).neg();
+        let y_c1_bit = Boolean::alloc(cs.ns(|| "alloc y c1 bit"), || {
+            if pk.y.c1.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                Ok(pk.y.c1.get_value().get()?.into_repr() > half)
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_c0_bit = Boolean::alloc(cs.ns(|| "alloc y c0 bit"), || {
+            if pk.y.c0.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                Ok(pk.y.c0.get_value().get()?.into_repr() > half)
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_eq_bit = Boolean::alloc(cs.ns(|| "alloc y eq bit"), || {
+            if pk.y.c0.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                Ok(pk.y.c0.get_value().get()?.into_repr() == half)
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_bit = Boolean::alloc(cs.ns(|| "alloc y bit"), || {
+            if pk.y.c1.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                if pk.y.c1.get_value().get()?.into_repr() > half {
+                    Ok(true)
+                } else if pk.y.c1.get_value().get()?.into_repr() == half
+                    && pk.y.c0.get_value().get()?.into_repr() > half
+                {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_c1_adjusted = FpGadget::alloc(cs.ns(|| "alloc y c1"), || {
+            if pk.y.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                let y_value = pk.y.c1.get_value().get()?;
+                if y_value.into_repr() > half {
+                    Ok(y_value - &(P::Fp::from_repr(half) + &P::Fp::one()))
+                } else {
+                    Ok(y_value)
+                }
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_c0_adjusted = FpGadget::alloc(cs.ns(|| "alloc y c0"), || {
+            if pk.y.get_value().is_some() {
+                let half = P::Fp::modulus_minus_one_div_two();
+                let y_value = pk.y.c0.get_value().get()?;
+                if y_value.into_repr() > half {
+                    Ok(y_value - &(P::Fp::from_repr(half) + &P::Fp::one()))
+                } else {
+                    Ok(y_value)
+                }
+            } else {
+                Err(SynthesisError::AssignmentMissing)
+            }
+        })?;
+        let y_c1_bit_lc = y_c1_bit.lc(CS::one(), half_plus_one_neg);
+        cs.enforce(
+            || "check y bit c1",
+            |lc| lc + (P::Fp::one(), CS::one()),
+            |lc| pk.y.c1.get_variable() + y_c1_bit_lc + lc,
+            |lc| y_c1_adjusted.get_variable() + lc,
+        );
+        let y_c1_adjusted_bits = &y_c1_adjusted.to_bits(cs.ns(|| "y c1 adjusted to bits"))?;
+        Boolean::enforce_smaller_or_equal_than::<_, _, P::Fp, _>(
+            cs.ns(|| "enforce y c1 smaller than modulus minus one div two"),
+            y_c1_adjusted_bits,
+            P::Fp::modulus_minus_one_div_two(),
+        )?;
+        let y_c0_bit_lc = y_c0_bit.lc(CS::one(), half_plus_one_neg);
+        cs.enforce(
+            || "check y bit c0",
+            |lc| lc + (P::Fp::one(), CS::one()),
+            |lc| pk.y.c0.get_variable() + y_c0_bit_lc + lc,
+            |lc| y_c0_adjusted.get_variable() + lc,
+        );
+        let y_c0_adjusted_bits = &y_c0_adjusted.to_bits(cs.ns(|| "y c0 adjusted to bits"))?;
+        Boolean::enforce_smaller_or_equal_than::<_, _, P::Fp, _>(
+            cs.ns(|| "enforce y c0 smaller than modulus minus one div two"),
+            y_c0_adjusted_bits,
+            P::Fp::modulus_minus_one_div_two(),
+        )?;
+
+        // (1-a)*(b*c) == o - a
+        // a is c1
+        // b is y_eq
+        // c is c0
+
+        let bc = Boolean::and(cs.ns(|| "and bc"), &y_eq_bit, &y_c0_bit)?;
+
+        cs.enforce(
+            || "enforce y bit derived correctly",
+            |lc| lc + (P::Fp::one(), CS::one()) + y_c1_bit.lc(CS::one(), P::Fp::one().neg()),
+            |_| bc.lc(CS::one(), P::Fp::one()),
+            |lc| {
+                lc + y_bit.lc(CS::one(), P::Fp::one()) + y_c1_bit.lc(CS::one(), P::Fp::one().neg())
+            },
+        );
+
+        Ok(y_bit)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
+    use algebra::{
+        bls12_377::{
+            Fr as Bls12_377Fr, G1Projective as Bls12_377G1Projective,
+            G2Projective as Bls12_377G2Projective, Parameters as Bls12_377Parameters,
+        },
+        curves::bls12::Bls12Parameters,
+        sw6::Fr as SW6Fr,
+        PrimeField, ProjectiveCurve, UniformRand,
+    };
+    use r1cs_core::ConstraintSystem;
+    use r1cs_std::{
+        alloc::AllocGadget,
+        fields::FieldGadget,
+        groups::curves::short_weierstrass::bls12::{G1Gadget, G2Gadget},
+        test_constraint_system::TestConstraintSystem,
+        Assignment,
+    };
+
+    use super::YToBitGadget;
+
+    #[test]
+    fn test_y_to_bit_g1() {
+        let rng = &mut XorShiftRng::from_seed([
+            0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc,
+            0x06, 0x54,
+        ]);
+        for i in 0..10 {
+            let secret_key = Bls12_377Fr::rand(rng);
+
+            let generator = Bls12_377G1Projective::prime_subgroup_generator();
+            let pub_key = generator.clone().mul(secret_key);
+
+            let half = <Bls12_377Parameters as Bls12Parameters>::Fp::modulus_minus_one_div_two();
+
+            {
+                let mut cs = TestConstraintSystem::<SW6Fr>::new();
+
+                let pk =
+                    G1Gadget::<Bls12_377Parameters>::alloc(&mut cs.ns(|| "alloc"), || Ok(pub_key))
+                        .unwrap();
+
+                let y_bit =
+                    YToBitGadget::<Bls12_377Parameters>::y_to_bit_g1(cs.ns(|| "y to bit"), &pk)
+                        .unwrap();
+
+                assert_eq!(
+                    pk.y.get_value().get().unwrap().into_repr() > half,
+                    y_bit.get_value().get().unwrap()
+                );
+
+                if i == 0 {
+                    println!("number of constraints: {}", cs.num_constraints());
+                }
+
+                assert!(cs.is_satisfied());
+            }
+        }
+    }
+
+    #[test]
+    fn test_y_to_bit_g2() {
+        let rng = &mut XorShiftRng::from_seed([
+            0x5d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc,
+            0x06, 0x54,
+        ]);
+        for i in 0..10 {
+            let secret_key = Bls12_377Fr::rand(rng);
+
+            let generator = Bls12_377G2Projective::prime_subgroup_generator();
+            let pub_key = generator.clone().mul(secret_key);
+
+            let half = <Bls12_377Parameters as Bls12Parameters>::Fp::modulus_minus_one_div_two();
+
+            {
+                let mut cs = TestConstraintSystem::<SW6Fr>::new();
+
+                let pk =
+                    G2Gadget::<Bls12_377Parameters>::alloc(&mut cs.ns(|| "alloc"), || Ok(pub_key))
+                        .unwrap();
+
+                let y_bit =
+                    YToBitGadget::<Bls12_377Parameters>::y_to_bit_g2(cs.ns(|| "y to bit"), &pk)
+                        .unwrap();
+
+                if pk.y.c1.get_value().get().unwrap().into_repr() > half
+                    || (pk.y.c1.get_value().get().unwrap().into_repr() == half
+                        && pk.y.c0.get_value().get().unwrap().into_repr() > half)
+                {
+                    assert_eq!(true, y_bit.get_value().get().unwrap());
+                } else {
+                    assert_eq!(false, y_bit.get_value().get().unwrap());
+                }
+
+                if i == 0 {
+                    println!("number of constraints: {}", cs.num_constraints());
+                }
+
+                if !cs.is_satisfied() {
+                    println!("{}", cs.which_is_unsatisfied().unwrap());
+                }
+                assert!(cs.is_satisfied());
+            }
+        }
+    }
+}

--- a/bls/snark/src/lib.rs
+++ b/bls/snark/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod encoding;
-pub mod gadgets;
 
 #[macro_use]
 extern crate log;
@@ -7,10 +6,10 @@ extern crate log;
 use bls_zexe::PublicKey;
 
 use std::{
-    os::raw::{c_ushort, c_uint, c_int},
-    slice,
-    fmt::Display,
     error::Error,
+    fmt::Display,
+    os::raw::{c_int, c_uint, c_ushort},
+    slice,
 };
 
 fn convert_result_to_bool<T, E: Display, F: Fn() -> Result<T, E>>(f: F) -> bool {
@@ -35,8 +34,9 @@ pub extern "C" fn encode_epoch_block_to_bytes(
 ) -> bool {
     convert_result_to_bool::<_, Box<dyn Error>, _>(|| {
         let aggregated_public_key = unsafe { &*in_aggregated_public_key };
-        let added_public_keys_ptrs =
-            unsafe { slice::from_raw_parts(in_added_public_keys, in_added_public_keys_len as usize) };
+        let added_public_keys_ptrs = unsafe {
+            slice::from_raw_parts(in_added_public_keys, in_added_public_keys_len as usize)
+        };
         let added_public_keys = added_public_keys_ptrs
             .to_vec()
             .into_iter()


### PR DESCRIPTION
- Creates a new `gadgets` crate which will contain all gadgets. This should improve compilation times, as well as have better separation between things that are gadgets and higher level circuits which are application specific
- Adds point compression gadget from @kobigurk's PR https://github.com/celo-org/bls-zexe/pull/73