### PR TITLE
Add Slice Update gadget

### DIFF
--- a/bls/gadgets/src/bitmap.rs
+++ b/bls/gadgets/src/bitmap.rs
@@ -7,52 +7,61 @@ use r1cs_std::{
     Assignment,
 };
 
-/// Enforces that there are no more than `max_zeros` present in the provided bitmap
-pub fn enforce_maximum_zeros_in_bitmap<F: PrimeField, CS: ConstraintSystem<F>>(
+/// Enforces that there are no more than `max_occurrences` of `value` (0 or 1)
+/// present in the provided bitmap
+pub fn enforce_maximum_occurrences_in_bitmap<F: PrimeField, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     bitmap: &[Boolean],
-    max_zeros: u64,
+    max_occurrences: u64,
+    value: bool,
 ) -> Result<(), SynthesisError> {
+    let mut value_fp = F::one();
+    if !value {
+        value_fp = value_fp.neg();
+    }
     // If we're in setup mode, we skip the bit counting part since the bitmap
     // will be empty
     let is_setup = bitmap.iter().all(|bit| bit.get_value().is_none());
 
-    // Calculate the number of zeros
-    let mut num_zeros = 0;
-    let mut num_zeros_lc = LinearCombination::zero();
-    // For each bit, increment the number of zeros
-    // if the bit was a 0. We calculate both the number of zeros
+    let mut occurrences = 0;
+    let mut occurrences_lc = LinearCombination::zero();
+    // For each bit, increment the number of occurences if the bit matched `value`
+    // We calculate both the number of occurrences
     // and a linear combination over it, in order to do 2 things:
-    // 1. enforce that num_zeros < maximum_zeros
-    // 2. enforce that num_zeros was calculated correctly from the bitmap
+    // 1. enforce that occurrences < maximum_occurences
+    // 2. enforce that occurrences was calculated correctly from the bitmap
     for bit in bitmap {
         // Update the constraints
-        num_zeros_lc += (F::one(), CS::one());
-        let zero_lc = bit.lc(CS::one(), F::one().neg());
-        num_zeros_lc = num_zeros_lc + zero_lc;
+        if !value {
+            // add 1 here only for zeros
+            occurrences_lc += (F::one(), CS::one());
+        }
+        occurrences_lc = occurrences_lc + bit.lc(CS::one(), value_fp);
 
         // Update our count
         if !is_setup {
-            let is_zero = !bit.get_value().get()?;
-            num_zeros += is_zero as u8;
+            let got_value = bit.get_value().get()?;
+            occurrences += (got_value == value) as u8;
         }
     }
-    // Rebind `num_zeros` to a constraint
-    let num_zeros = FpGadget::alloc(&mut cs.ns(|| "num zeros"), || Ok(F::from(num_zeros)))?;
+    // Rebind `occurrences` to a constraint
+    let occurrences = FpGadget::alloc(&mut cs.ns(|| "num occurrences"), || {
+        Ok(F::from(occurrences))
+    })?;
 
-    let num_zeros_bits = &num_zeros.to_bits(&mut cs.ns(|| "num zeros to bits"))?;
+    let occurrences_bits = &occurrences.to_bits(&mut cs.ns(|| "num occurrences to bits"))?;
     Boolean::enforce_smaller_or_equal_than::<_, _, F, _>(
-        &mut cs.ns(|| "enforce maximum number of zeros"),
-        num_zeros_bits,
-        F::from(max_zeros).into_repr(),
+        &mut cs.ns(|| "enforce maximum number of occurrences"),
+        occurrences_bits,
+        F::from(max_occurrences).into_repr(),
     )?;
 
-    // Enforce that we have correctly counted the number of zeros
+    // Enforce that we have correctly counted the number of occurrences
     cs.enforce(
-        || "enforce num zeros lc equal to num",
-        |_| num_zeros_lc,
+        || "enforce num occurrences lc equal to num",
+        |_| occurrences_lc,
         |lc| lc + (F::one(), CS::one()),
-        |lc| num_zeros.get_variable() + lc,
+        |lc| occurrences.get_variable() + lc,
     );
 
     Ok(())
@@ -64,33 +73,67 @@ mod tests {
     use algebra::bls12_377::Fq;
     use r1cs_std::test_constraint_system::TestConstraintSystem;
 
-    fn cs_enforce(bitmap: &[bool], max_zeros: u64) -> TestConstraintSystem<Fq> {
+    fn cs_enforce_value(
+        bitmap: &[bool],
+        max_number: u64,
+        is_one: bool,
+    ) -> TestConstraintSystem<Fq> {
         let mut cs = TestConstraintSystem::<Fq>::new();
         let bitmap = bitmap
             .into_iter()
             .map(|b| Boolean::constant(*b))
             .collect::<Vec<_>>();
-        enforce_maximum_zeros_in_bitmap(&mut cs, &bitmap, max_zeros).unwrap();
+        enforce_maximum_occurrences_in_bitmap(&mut cs, &bitmap, max_number, is_one).unwrap();
         cs
     }
 
-    #[test]
-    fn one() {
-        assert!(cs_enforce(&[true], 0).is_satisfied());
+    mod zeros {
+        use super::*;
+
+        #[test]
+        fn one_zero_allowed() {
+            assert!(cs_enforce_value(&[false], 1, false).is_satisfied());
+        }
+
+        #[test]
+        fn no_zeros_allowed() {
+            assert!(!cs_enforce_value(&[false], 0, false).is_satisfied());
+        }
+
+        #[test]
+        fn three_zeros_allowed() {
+            assert!(cs_enforce_value(&[false, true, true, false, false], 3, false).is_satisfied());
+        }
+
+        #[test]
+        fn four_zeros_not_allowed() {
+            assert!(
+                !cs_enforce_value(&[false, false, true, false, false], 3, false).is_satisfied()
+            );
+        }
     }
 
-    #[test]
-    fn no_zeros_allowed() {
-        assert!(!cs_enforce(&[false], 0).is_satisfied());
-    }
+    mod ones {
+        use super::*;
 
-    #[test]
-    fn three_zeros_allowed() {
-        assert!(cs_enforce(&[false, true, true, false, false], 3).is_satisfied());
-    }
+        #[test]
+        fn one_one_allowed() {
+            assert!(cs_enforce_value(&[true], 1, true).is_satisfied());
+        }
 
-    #[test]
-    fn four_zeros_not_allowed() {
-        assert!(!cs_enforce(&[false, false, true, false, false], 3).is_satisfied());
+        #[test]
+        fn no_ones_allowed() {
+            assert!(!cs_enforce_value(&[true], 0, true).is_satisfied());
+        }
+
+        #[test]
+        fn three_ones_allowed() {
+            assert!(cs_enforce_value(&[false, true, true, true, false], 3, true).is_satisfied());
+        }
+
+        #[test]
+        fn four_ones_not_allowed() {
+            assert!(!cs_enforce_value(&[true, true, true, true, false], 3, true).is_satisfied());
+        }
     }
 }

--- a/bls/gadgets/src/bitmap.rs
+++ b/bls/gadgets/src/bitmap.rs
@@ -17,6 +17,7 @@ pub fn enforce_maximum_occurrences_in_bitmap<F: PrimeField, CS: ConstraintSystem
 ) -> Result<(), SynthesisError> {
     let mut value_fp = F::one();
     if !value {
+        // using the opposite value if we are counting 0s
         value_fp = value_fp.neg();
     }
     // If we're in setup mode, we skip the bit counting part since the bitmap

--- a/bls/gadgets/src/bls.rs
+++ b/bls/gadgets/src/bls.rs
@@ -1,4 +1,4 @@
-use crate::enforce_maximum_zeros_in_bitmap;
+use crate::enforce_maximum_occurrences_in_bitmap;
 use algebra::{PairingEngine, PrimeField, ProjectiveCurve};
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use r1cs_std::{
@@ -151,7 +151,7 @@ where
         message_hash: &P::G1Gadget,
         maximum_non_signers: u64,
     ) -> Result<(P::G1PreparedGadget, P::G2PreparedGadget), SynthesisError> {
-        enforce_maximum_zeros_in_bitmap(&mut cs, signed_bitmap, maximum_non_signers)?;
+        enforce_maximum_occurrences_in_bitmap(&mut cs, signed_bitmap, maximum_non_signers, false)?;
 
         let prepared_message_hash =
             P::prepare_g1(cs.ns(|| "prepared message hash"), &message_hash)?;

--- a/bls/gadgets/src/hash_to_group.rs
+++ b/bls/gadgets/src/hash_to_group.rs
@@ -68,6 +68,7 @@ fn blake2xs_params(
     }
 }
 
+/// Gadget for checking that hashes to group are computed correctly
 pub struct HashToGroupGadget<P> {
     parameters_type: PhantomData<P>,
 }

--- a/bls/gadgets/src/lib.rs
+++ b/bls/gadgets/src/lib.rs
@@ -12,5 +12,5 @@ pub use y_to_bit::YToBitGadget;
 mod hash_to_group;
 pub use hash_to_group::HashToGroupGadget;
 
-mod validator;
-pub use validator::SliceUpdateGadget;
+mod slice_update;
+pub use slice_update::SliceUpdateGadget;

--- a/bls/gadgets/src/lib.rs
+++ b/bls/gadgets/src/lib.rs
@@ -4,10 +4,13 @@ mod bls;
 pub use bls::BlsVerifyGadget;
 
 mod bitmap;
-pub use bitmap::enforce_maximum_zeros_in_bitmap;
+pub use bitmap::enforce_maximum_occurrences_in_bitmap;
 
 mod y_to_bit;
 pub use y_to_bit::YToBitGadget;
 
 mod hash_to_group;
 pub use hash_to_group::HashToGroupGadget;
+
+mod validator;
+pub use validator::ValidatorUpdateGadget;

--- a/bls/gadgets/src/lib.rs
+++ b/bls/gadgets/src/lib.rs
@@ -13,4 +13,4 @@ mod hash_to_group;
 pub use hash_to_group::HashToGroupGadget;
 
 mod validator;
-pub use validator::ValidatorUpdateGadget;
+pub use validator::SliceUpdateGadget;

--- a/bls/gadgets/src/slice_update.rs
+++ b/bls/gadgets/src/slice_update.rs
@@ -1,12 +1,8 @@
-use algebra::{PrimeField, Group};
-use r1cs_core::{ConstraintSystem, SynthesisError};
-use r1cs_std::{
-    boolean::Boolean,
-};
-use std::marker::PhantomData;
-
 use crate::enforce_maximum_occurrences_in_bitmap;
-use r1cs_std::groups::GroupGadget;
+use algebra::{Group, PrimeField};
+use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_std::{boolean::Boolean, groups::GroupGadget};
+use std::marker::PhantomData;
 
 /// Gadget for checking that slice diffs are computed correctly
 pub struct SliceUpdateGadget<G, F, GG> {
@@ -15,13 +11,14 @@ pub struct SliceUpdateGadget<G, F, GG> {
     gadget_type: PhantomData<GG>,
 }
 
-impl<G, F, GG> SliceUpdateGadget<G, F, GG> where 
+impl<G, F, GG> SliceUpdateGadget<G, F, GG>
+where
     G: Group,
     F: PrimeField,
-    GG: GroupGadget<G, F>
- {
+    GG: GroupGadget<G, F>,
+{
     /// Enforces that the old slice's elements are replaced by the new slice's elements
-    /// at the indexes where the bitmap is set to 1, and that no more than 
+    /// at the indexes where the bitmap is set to 1, and that no more than
     /// `maximum_removed` elements were changed.
     ///
     /// # Panics
@@ -38,21 +35,11 @@ impl<G, F, GG> SliceUpdateGadget<G, F, GG> where
         assert_eq!(new_elements.len(), bitmap.len());
         // check that no more than `maximum_removed` 1s exist in
         // the provided bitmap
-        enforce_maximum_occurrences_in_bitmap(
-            &mut cs,
-            bitmap,
-            maximum_removed,
-            true,
-        )?;
+        enforce_maximum_occurrences_in_bitmap(&mut cs, bitmap, maximum_removed, true)?;
 
         // check that the new_elements are correctly computed from the
         // bitmap and the old slice
-        Self::enforce_slice_update(
-            &mut cs,
-            old_elements,
-            new_elements,
-            bitmap,
-        )
+        Self::enforce_slice_update(&mut cs, old_elements, new_elements, bitmap)
     }
 
     /// Checks that if the i_th bit in the provided bitmap is set to 1:
@@ -65,11 +52,7 @@ impl<G, F, GG> SliceUpdateGadget<G, F, GG> where
         bitmap: &[Boolean],
     ) -> Result<Vec<GG>, SynthesisError> {
         let mut updated_elements = Vec::with_capacity(old_elements.len());
-        for (i, (pk, bit)) in old_elements
-            .iter()
-            .zip(bitmap)
-            .enumerate()
-        {
+        for (i, (pk, bit)) in old_elements.iter().zip(bitmap).enumerate() {
             // if the bit is 1, the element is replaced
             let new_element = GG::conditionally_select(
                 cs.ns(|| format!("cond_select {}", i)),
@@ -94,9 +77,7 @@ mod test {
         PairingEngine, ProjectiveCurve, UniformRand,
     };
     use r1cs_std::{
-        alloc::AllocGadget,
-        groups::bls12::G2Gadget,
-        boolean::Boolean,
+        alloc::AllocGadget, boolean::Boolean, groups::bls12::G2Gadget,
         test_constraint_system::TestConstraintSystem,
     };
 
@@ -132,8 +113,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(cs.is_satisfied(), satisfied);
-        res
-            .into_iter()
+        res.into_iter()
             .map(|x| x.get_value().unwrap())
             .collect::<Vec<_>>()
     }

--- a/bls/gadgets/src/validator.rs
+++ b/bls/gadgets/src/validator.rs
@@ -1,0 +1,259 @@
+use algebra::curves::models::bls12::Bls12Parameters;
+use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_std::{
+    boolean::Boolean, groups::curves::short_weierstrass::bls12::G2Gadget, select::CondSelectGadget,
+};
+use std::marker::PhantomData;
+
+use crate::enforce_maximum_occurrences_in_bitmap;
+
+/// Gadget for checking that validator diffs are computed correctly
+pub struct ValidatorUpdateGadget<P: Bls12Parameters> {
+    parameters_type: PhantomData<P>,
+}
+
+impl<P: Bls12Parameters> ValidatorUpdateGadget<P> {
+    /// Enforces that the validator set is transitioned correctly according to the bitmap
+    /// and that no more than `maximum_removed_validators` pubkeys were removed.
+    ///
+    /// Notes:
+    /// - We assume that the number of validators **does not** change over time.
+    /// - A 1 in the bitmap means that the old validator is replaced by the new one
+    ///
+    /// # Panics
+    /// - If `old_pub_keys.len() != `removed_validators_bitmap.len()`
+    /// - If `new_pub_keys.len() != `removed_validators_bitmap.len()`
+    pub fn update<CS: ConstraintSystem<P::Fp>>(
+        mut cs: CS,
+        old_pub_keys: &[G2Gadget<P>],
+        new_pub_keys: &[G2Gadget<P>],
+        removed_validators_bitmap: &[Boolean],
+        maximum_removed_validators: u64,
+    ) -> Result<Vec<G2Gadget<P>>, SynthesisError> {
+        assert_eq!(old_pub_keys.len(), removed_validators_bitmap.len());
+        assert_eq!(new_pub_keys.len(), removed_validators_bitmap.len());
+        // check that no more than `maximum_removed_validators` 1s exist in
+        // the provided bitmap
+        enforce_maximum_occurrences_in_bitmap(
+            &mut cs,
+            removed_validators_bitmap,
+            maximum_removed_validators,
+            true,
+        )?;
+
+        // check that the new_pub_keys are correctly computed from the
+        // bitmap and the old pubkeys
+        let new_validator_set = Self::enforce_validator_set(
+            &mut cs,
+            old_pub_keys,
+            new_pub_keys,
+            removed_validators_bitmap,
+        )?;
+        Ok(new_validator_set)
+    }
+
+    /// Checks that if the i_th bit in the provided bitmap is set to 1:
+    /// the i_th validator in the old pubkeys array is replaced
+    /// with the i_th validator in the new pubkeys array
+    fn enforce_validator_set<CS: ConstraintSystem<P::Fp>>(
+        cs: &mut CS,
+        old_pub_keys: &[G2Gadget<P>],
+        new_pub_keys: &[G2Gadget<P>],
+        removed_validators_bitmap: &[Boolean],
+    ) -> Result<Vec<G2Gadget<P>>, SynthesisError> {
+        let mut new_validator_set = Vec::with_capacity(old_pub_keys.len());
+        for (i, (pk, bit)) in old_pub_keys
+            .iter()
+            .zip(removed_validators_bitmap)
+            .enumerate()
+        {
+            // if the bit is 1, the validator is replaced
+            let new_pub_key = G2Gadget::<P>::conditionally_select(
+                cs.ns(|| format!("cond_select {}", i)),
+                bit,
+                &new_pub_keys[i],
+                pk,
+            )?;
+            new_validator_set.push(new_pub_key);
+        }
+        Ok(new_validator_set)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::borrow::Borrow;
+
+    use algebra::{
+        bls12_377::{Bls12_377, Parameters as Bls12_377Parameters},
+        curves::{bls12::Bls12Parameters, short_weierstrass_jacobian::GroupProjective},
+        PairingEngine, ProjectiveCurve, UniformRand,
+    };
+    use r1cs_std::{
+        alloc::AllocGadget, boolean::Boolean, groups::GroupGadget,
+        test_constraint_system::TestConstraintSystem,
+    };
+
+    fn cs_update<E: PairingEngine, P: Bls12Parameters>(
+        old_pubkeys: &[E::G2Projective],
+        new_pubkeys: &[E::G2Projective],
+        bitmap: &[bool],
+        max_removed_validators: u64,
+        satisfied: bool,
+    ) -> Vec<GroupProjective<P::G2Parameters>>
+    where
+        // TODO: Is there a way to remove this awkward type bound?
+        E::G2Projective: Borrow<GroupProjective<P::G2Parameters>>,
+    {
+        let mut cs = TestConstraintSystem::<P::Fp>::new();
+
+        // convert the arguments to constraints
+        let old_pub_keys = pubkeys_to_constraints::<P, E>(&mut cs, old_pubkeys, "old");
+        let new_pub_keys = pubkeys_to_constraints::<P, E>(&mut cs, new_pubkeys, "new");
+        let bitmap = bitmap
+            .into_iter()
+            .map(|b| Boolean::constant(*b))
+            .collect::<Vec<_>>();
+
+        // check the result and return the inner data
+        let gadget: Vec<G2Gadget<P>> = ValidatorUpdateGadget::<P>::update::<_>(
+            cs.ns(|| "validator update"),
+            &old_pub_keys,
+            &new_pub_keys,
+            &bitmap,
+            max_removed_validators,
+        )
+        .unwrap();
+        assert_eq!(cs.is_satisfied(), satisfied);
+        gadget
+            .into_iter()
+            .map(|x| x.get_value().unwrap())
+            .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn all_validators_removed() {
+        let (_, old_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let (_, new_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let result = cs_update::<Bls12_377, Bls12_377Parameters>(
+            &old_pubkeys,
+            &new_pubkeys,
+            &[true; 5],
+            5,
+            true,
+        );
+        assert_eq!(new_pubkeys, result);
+    }
+
+    #[test]
+    fn one_validator_removed() {
+        let (_, mut old_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let (_, new_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let result = cs_update::<Bls12_377, Bls12_377Parameters>(
+            &old_pubkeys,
+            &new_pubkeys,
+            &[true, false, false, false, false],
+            3,
+            true,
+        );
+        // the first pubkey was replaced with the 1st pubkey from the
+        // new set
+        old_pubkeys[0] = new_pubkeys[0];
+        assert_eq!(old_pubkeys, result);
+    }
+
+    #[test]
+    fn some_validators_removed() {
+        let (_, old_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let (_, mut new_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let result = cs_update::<Bls12_377, Bls12_377Parameters>(
+            &old_pubkeys,
+            &new_pubkeys,
+            &[false, true, true, false, true],
+            3,
+            true,
+        );
+        // all validators were replaced except the 1st and 4th
+        new_pubkeys[0] = old_pubkeys[0];
+        new_pubkeys[3] = old_pubkeys[3];
+        assert_eq!(new_pubkeys, result);
+    }
+
+    #[test]
+    fn cannot_remove_more_validators_than_allowed() {
+        let (_, old_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let (_, new_pubkeys) = keygen_mul::<Bls12_377>(5);
+        cs_update::<Bls12_377, Bls12_377Parameters>(
+            &old_pubkeys,
+            &new_pubkeys,
+            &[true; 5], // tries to remove all 5, when only 4 are allowed
+            4,
+            false,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_bitmap_length() {
+        let (_, old_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let (_, new_pubkeys) = keygen_mul::<Bls12_377>(5);
+        cs_update::<Bls12_377, Bls12_377Parameters>(
+            &old_pubkeys,
+            &new_pubkeys,
+            &[true; 3],
+            5,
+            false,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_validator_set_wrong_size() {
+        let (_, old_pubkeys) = keygen_mul::<Bls12_377>(5);
+        let (_, new_pubkeys) = keygen_mul::<Bls12_377>(4);
+        cs_update::<Bls12_377, Bls12_377Parameters>(
+            &old_pubkeys,
+            &new_pubkeys,
+            &[true; 5],
+            5,
+            false,
+        );
+    }
+
+    fn pubkeys_to_constraints<P: Bls12Parameters, E: PairingEngine>(
+        cs: &mut TestConstraintSystem<P::Fp>,
+        pubkeys: &[E::G2Projective],
+        personalization: &str,
+    ) -> Vec<G2Gadget<P>>
+    where
+        E::G2Projective: Borrow<GroupProjective<P::G2Parameters>>,
+    {
+        pubkeys
+            .iter()
+            .enumerate()
+            .map(|(i, x)| {
+                G2Gadget::<P>::alloc(
+                    &mut cs.ns(|| format!("alloc {} {}", personalization, i)),
+                    || Ok(*x),
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
+    fn keygen_mul<E: PairingEngine>(num: usize) -> (Vec<E::Fr>, Vec<E::G2Projective>) {
+        let rng = &mut rand::thread_rng();
+        let generator = E::G2Projective::prime_subgroup_generator();
+
+        let mut secret_keys = Vec::new();
+        let mut public_keys = Vec::new();
+        for _ in 0..num {
+            let secret_key = E::Fr::rand(rng);
+            let public_key = generator.mul(secret_key);
+            secret_keys.push(secret_key);
+            public_keys.push(public_key);
+        }
+        (secret_keys, public_keys)
+    }
+}


### PR DESCRIPTION
Adds gadget which enforces that a slice's elements are replaced by another slice's elements at the indexes where a bitmap is set to 1. We will use this for checking that validator diffs are computed correctly.

Based on the code from https://github.com/celo-org/bls-zexe/pull/73.