### PR TITLE
Improve FFI API & ensure setup works

### DIFF
--- a/crates/bls-crypto/examples/simple_signature.rs
+++ b/crates/bls-crypto/examples/simple_signature.rs
@@ -52,15 +52,15 @@ fn main() {
     println!("sig3: {}", hex::encode(to_bytes!(sig3.get_sig()).unwrap()));
 
     let apk = PublicKey::aggregate(&[
-        &sk1.to_public(),
-        &sk2.to_public(),
-        &sk3.to_public(),
-        &sk3.to_public(),
+        sk1.to_public(),
+        sk2.to_public(),
+        sk3.to_public(),
+        sk3.to_public(),
     ]);
     println!("apk: {}", hex::encode(to_bytes!(apk.get_pk()).unwrap()));
-    let asig1 = Signature::aggregate(&[&sig1, &sig3]);
-    let asig2 = Signature::aggregate(&[&sig2, &sig3]);
-    let asig = Signature::aggregate(&[&asig1, &asig2]);
+    let asig1 = Signature::aggregate(&[sig1, sig3.clone()]);
+    let asig2 = Signature::aggregate(&[sig2, sig3]);
+    let asig = Signature::aggregate(&[asig1, asig2]);
     println!("asig: {}", hex::encode(to_bytes!(asig.get_sig()).unwrap()));
     apk.verify(&message.as_bytes(), &[], &asig, &try_and_increment)
         .unwrap();

--- a/crates/bls-crypto/src/bls/keys.rs
+++ b/crates/bls-crypto/src/bls/keys.rs
@@ -78,14 +78,14 @@ impl PrivateKey {
         hash_to_g1: &H,
     ) -> Result<Signature, Box<dyn Error>> {
         Ok(Signature::from_sig(
-            &hash_to_g1
+            hash_to_g1
                 .hash::<Bls12_377Parameters>(domain, message, extra_data)?
                 .mul(self.sk),
         ))
     }
 
     pub fn to_public(&self) -> PublicKey {
-        PublicKey::from_pk(&G2Projective::prime_subgroup_generator().mul(self.sk))
+        PublicKey::from_pk(G2Projective::prime_subgroup_generator().mul(self.sk))
     }
 }
 
@@ -129,8 +129,8 @@ pub struct PublicKey {
 }
 
 impl PublicKey {
-    pub fn from_pk(pk: &G2Projective) -> PublicKey {
-        PublicKey { pk: pk.clone() }
+    pub fn from_pk(pk: G2Projective) -> PublicKey {
+        PublicKey { pk }
     }
 
     pub fn get_pk(&self) -> G2Projective {
@@ -138,10 +138,10 @@ impl PublicKey {
     }
 
     pub fn clone(&self) -> PublicKey {
-        PublicKey::from_pk(&self.pk)
+        PublicKey::from_pk(self.pk)
     }
 
-    pub fn aggregate(public_keys: &[&PublicKey]) -> PublicKey {
+    pub fn aggregate(public_keys: &[PublicKey]) -> PublicKey {
         let mut apk = G2Projective::zero();
         for i in public_keys.iter() {
             apk = apk + &(*i).pk;
@@ -181,7 +181,7 @@ impl PublicKey {
 
         let chosen_y = if y_over_half { bigger } else { smaller };
         let pk = G2Affine::new(x, chosen_y, false);
-        Ok(PublicKey::from_pk(&pk.into_projective()))
+        Ok(PublicKey::from_pk(pk.into_projective()))
     }
 
     pub fn verify<H: HashToG1>(
@@ -287,15 +287,15 @@ pub struct Signature {
 }
 
 impl Signature {
-    pub fn from_sig(sig: &G1Projective) -> Signature {
-        Signature { sig: sig.clone() }
+    pub fn from_sig(sig: G1Projective) -> Signature {
+        Signature { sig }
     }
 
     pub fn get_sig(&self) -> G1Projective {
         self.sig
     }
 
-    pub fn aggregate(signatures: &[&Signature]) -> Signature {
+    pub fn aggregate(signatures: &[Signature]) -> Signature {
         let mut asig = G1Projective::zero();
         for i in signatures.iter() {
             asig = asig + &(*i).sig;
@@ -341,7 +341,7 @@ impl FromBytes for Signature {
         let negy = -y;
         let chosen_y = if (y <= negy) ^ y_over_half { y } else { negy };
         let sig = G1Affine::new(x, chosen_y, false);
-        Ok(Signature::from_sig(&sig.into_projective()))
+        Ok(Signature::from_sig(sig.into_projective()))
     }
 }
 
@@ -392,12 +392,12 @@ impl PublicKeyCache {
         Some(cache.get(data)?.clone())
     }
 
-    pub fn aggregate(public_keys: &[&PublicKey]) -> PublicKey {
+    pub fn aggregate(public_keys: &[PublicKey]) -> PublicKey {
         // The set of validators changes slowly, so for speed we will compute the
         // difference from the last call and do an incremental update
         let mut keys: HashSet<PublicKey> = HashSet::with_capacity(public_keys.len());
-        for key in public_keys.iter() {
-            keys.insert((*key).clone());
+        for key in public_keys {
+            keys.insert(key.clone());
         }
         let mut cache = AGGREGATE_CACHE.lock().unwrap();
         let mut combined = cache.combined;
@@ -412,7 +412,7 @@ impl PublicKeyCache {
 
         cache.keys = keys;
         cache.combined = combined;
-        PublicKey::from_pk(&combined)
+        PublicKey::from_pk(combined)
     }
 }
 
@@ -514,12 +514,13 @@ mod test {
 
         let sig1 = sk1.sign(&message[..], &[], &try_and_increment).unwrap();
         let sig2 = sk2.sign(&message[..], &[], &try_and_increment).unwrap();
+        let sigs = &[sig1, sig2];
 
-        let apk = PublicKeyCache::aggregate(&[&sk1.to_public(), &sk2.to_public()]);
-        let asig = Signature::aggregate(&[&sig1, &sig2]);
+        let apk = PublicKeyCache::aggregate(&[sk1.to_public(), sk2.to_public()]);
+        let asig = Signature::aggregate(sigs);
         apk.verify(&message[..], &[], &asig, &try_and_increment)
             .unwrap();
-        apk.verify(&message[..], &[], &sig1, &try_and_increment)
+        apk.verify(&message[..], &[], &sigs[0], &try_and_increment)
             .unwrap_err();
         sk1.to_public()
             .verify(&message[..], &[], &asig, &try_and_increment)
@@ -528,22 +529,22 @@ mod test {
         apk.verify(&message2[..], &[], &asig, &try_and_increment)
             .unwrap_err();
 
-        let apk2 = PublicKeyCache::aggregate(&[&sk1.to_public()]);
+        let apk2 = PublicKeyCache::aggregate(&[sk1.to_public()]);
         apk2.verify(&message[..], &[], &asig, &try_and_increment)
             .unwrap_err();
-        apk2.verify(&message[..], &[], &sig1, &try_and_increment)
+        apk2.verify(&message[..], &[], &sigs[0], &try_and_increment)
             .unwrap();
 
-        let apk3 = PublicKeyCache::aggregate(&[&sk2.to_public(), &sk1.to_public()]);
+        let apk3 = PublicKeyCache::aggregate(&[sk2.to_public(), sk1.to_public()]);
         apk3.verify(&message[..], &[], &asig, &try_and_increment)
             .unwrap();
-        apk3.verify(&message[..], &[], &sig1, &try_and_increment)
+        apk3.verify(&message[..], &[], &sigs[0], &try_and_increment)
             .unwrap_err();
 
-        let apk4 = PublicKey::aggregate(&[&sk1.to_public(), &sk2.to_public()]);
+        let apk4 = PublicKey::aggregate(&[sk1.to_public(), sk2.to_public()]);
         apk4.verify(&message[..], &[], &asig, &try_and_increment)
             .unwrap();
-        apk4.verify(&message[..], &[], &sig1, &try_and_increment)
+        apk4.verify(&message[..], &[], &sigs[0], &try_and_increment)
             .unwrap_err();
     }
 

--- a/crates/bls-crypto/src/lib.rs
+++ b/crates/bls-crypto/src/lib.rs
@@ -240,7 +240,7 @@ pub extern "C" fn compress_signature(
         let x = Fq::read(&signature[0..48]).unwrap();
         let y = Fq::read(&signature[48..96]).unwrap();
         let affine = G1Affine::new(x, y, false);
-        let sig = Signature::from_sig(&affine.into_projective());
+        let sig = Signature::from_sig(affine.into_projective());
         let mut obj_bytes = vec![];
         sig.write(&mut obj_bytes)?;
         obj_bytes.shrink_to_fit();
@@ -265,7 +265,7 @@ pub extern "C" fn compress_pubkey(
         let x = Fq2::read(&pubkey[0..96]).unwrap();
         let y = Fq2::read(&pubkey[96..192]).unwrap();
         let affine = G2Affine::new(x, y, false);
-        let pk = PublicKey::from_pk(&affine.into_projective());
+        let pk = PublicKey::from_pk(affine.into_projective());
         let mut obj_bytes = vec![];
         pk.write(&mut obj_bytes)?;
         obj_bytes.shrink_to_fit();
@@ -405,8 +405,8 @@ pub extern "C" fn aggregate_public_keys(
         let public_keys = public_keys_ptrs
             .to_vec()
             .into_iter()
-            .map(|pk| unsafe { &*pk })
-            .collect::<Vec<&PublicKey>>();
+            .map(|pk| unsafe { &*pk }.clone())
+            .collect::<Vec<PublicKey>>();
         let aggregated_public_key = PublicKeyCache::aggregate(&public_keys[..]);
         unsafe {
             *out_public_key = Box::into_raw(Box::new(aggregated_public_key));
@@ -430,11 +430,11 @@ pub extern "C" fn aggregate_public_keys_subtract(
         let public_keys = public_keys_ptrs
             .to_vec()
             .into_iter()
-            .map(|pk| unsafe { &*pk })
-            .collect::<Vec<&PublicKey>>();
+            .map(|pk| unsafe { &*pk }.clone())
+            .collect::<Vec<PublicKey>>();
         let aggregated_public_key_to_subtract = PublicKeyCache::aggregate(&public_keys[..]);
         let prepared_aggregated_public_key = PublicKey::from_pk(
-            &(aggregated_public_key.get_pk() - aggregated_public_key_to_subtract.get_pk()),
+            aggregated_public_key.get_pk() - aggregated_public_key_to_subtract.get_pk(),
         );
         unsafe {
             *out_public_key = Box::into_raw(Box::new(prepared_aggregated_public_key));
@@ -456,8 +456,8 @@ pub extern "C" fn aggregate_signatures(
         let signatures = signatures_ptrs
             .to_vec()
             .into_iter()
-            .map(|sig| unsafe { &*sig })
-            .collect::<Vec<&Signature>>();
+            .map(|sig| unsafe { &*sig }.clone())
+            .collect::<Vec<Signature>>();
         let aggregated_signature = Signature::aggregate(&signatures[..]);
         unsafe {
             *out_signature = Box::into_raw(Box::new(aggregated_signature));

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -40,7 +40,7 @@ where
         signed_bitmap: &[Boolean],
         message_hash: &P::G1Gadget,
         signature: &P::G1Gadget,
-        maximum_non_signers: u64,
+        maximum_non_signers: Option<u64>,
     ) -> Result<(), SynthesisError> {
         // Get the message hash and the aggregated public key based on the bitmap
         // and allowed number of non-signers
@@ -177,7 +177,7 @@ where
         pub_keys: &[P::G2Gadget],
         signed_bitmap: &[Boolean],
         message_hash: &P::G1Gadget,
-        maximum_non_signers: u64,
+        maximum_non_signers: Option<u64>,
     ) -> Result<(P::G1PreparedGadget, P::G2PreparedGadget), SynthesisError> {
         enforce_maximum_occurrences_in_bitmap(&mut cs, signed_bitmap, maximum_non_signers, false)?;
 
@@ -277,7 +277,7 @@ mod verify_one_message {
             &bitmap,
             &message_hash_var,
             &signature_var,
-            num_non_signers,
+            Some(num_non_signers),
         )
         .unwrap();
 

--- a/crates/bls-gadgets/src/lib.rs
+++ b/crates/bls-gadgets/src/lib.rs
@@ -16,6 +16,12 @@ use algebra::Field;
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use r1cs_std::{alloc::AllocGadget, boolean::Boolean};
 
+/// Helper which _must_ be used before trying to the inner values
+/// of a boolean vector
+pub fn is_setup(message: &[Boolean]) -> bool {
+    message.iter().any(|m| m.get_value().is_none())
+}
+
 pub fn constrain_bool<F: Field, CS: ConstraintSystem<F>>(
     cs: &mut CS,
     input: &[bool],

--- a/crates/epoch-snark/src/epoch_block.rs
+++ b/crates/epoch-snark/src/epoch_block.rs
@@ -5,19 +5,20 @@ use bls_gadgets::{bits_to_bytes, bytes_to_bits};
 
 pub static OUT_DOMAIN: &[u8] = b"ULforout";
 
-pub struct EpochBlock<'a> {
-    index: u16,
-    maximum_non_signers: u32,
-    aggregated_public_key: &'a PublicKey, // TODO: This might be redundant.
-    new_public_keys: &'a [&'a PublicKey],
+#[derive(Clone)]
+pub struct EpochBlock {
+    pub index: u16,
+    pub maximum_non_signers: u32,
+    pub new_public_keys: Vec<PublicKey>,
+    pub aggregated_public_key: PublicKey, // TODO: This might be redundant.
 }
 
-impl<'a> EpochBlock<'a> {
+impl EpochBlock {
     pub fn new(
         index: u16,
         maximum_non_signers: u32,
-        aggregated_public_key: &'a PublicKey,
-        new_public_keys: &'a [&PublicKey],
+        aggregated_public_key: PublicKey,
+        new_public_keys: Vec<PublicKey>,
     ) -> Self {
         Self {
             index,
@@ -38,7 +39,7 @@ impl<'a> EpochBlock<'a> {
         epoch_bits.extend_from_slice(&encode_u16(self.index)?);
         epoch_bits.extend_from_slice(&encode_u32(self.maximum_non_signers)?);
         epoch_bits.extend_from_slice(encode_public_key(&self.aggregated_public_key)?.as_slice());
-        for added_public_key in self.new_public_keys {
+        for added_public_key in &self.new_public_keys {
             epoch_bits.extend_from_slice(encode_public_key(&added_public_key)?.as_slice());
         }
         Ok(epoch_bits)

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -39,16 +39,15 @@ pub mod test_helpers {
     pub fn hash_epoch(epoch: &EpochData<Bls12_377>) -> G1Projective {
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
-            pubkeys.push(PublicKey::from_pk(&pk.unwrap()));
+            pubkeys.push(PublicKey::from_pk(pk.unwrap()));
         }
-        let pubkeys: Vec<&PublicKey> = pubkeys.iter().map(|x| x).collect();
 
         // Calculate the hash from our to_bytes function
         let epoch_bytes = EpochBlock::new(
             epoch.index.unwrap(),
             epoch.maximum_non_signers.unwrap(),
-            &PublicKey::from_pk(&epoch.aggregated_pub_key.unwrap()),
-            &pubkeys,
+            PublicKey::from_pk(epoch.aggregated_pub_key.unwrap()),
+            pubkeys,
         )
         .encode_to_bytes()
         .unwrap();
@@ -74,9 +73,9 @@ pub fn pack<F: PrimeField, P: FpParameters>(values: &[bool]) -> Vec<F> {
 
 pub fn to_fr<T: Into<u64>, CS: ConstraintSystem<Fr>>(
     cs: &mut CS,
-    num: T,
+    num: Option<T>,
 ) -> Result<FrGadget, SynthesisError> {
-    FrGadget::alloc(cs, || Ok(Fr::from(num.into())))
+    FrGadget::alloc(cs, || Ok(Fr::from(num.get()?.into())))
 }
 
 pub fn fr_to_bits<CS: ConstraintSystem<Fr>>(

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -4,7 +4,6 @@ use r1cs_std::{
     bls12_377::{G1PreparedGadget, G2Gadget, G2PreparedGadget, PairingGadget},
     boolean::Boolean,
     fields::fp::FpGadget,
-    Assignment,
 };
 
 use super::{constrain_bool, EpochData};
@@ -78,7 +77,7 @@ impl SingleUpdate<Bls12_377> {
                 previous_pubkeys,
                 &signed_bitmap,
                 &epoch_data.message_hash,
-                self.epoch_data.maximum_non_signers.get()? as u64,
+                self.epoch_data.maximum_non_signers.map(u64::from),
             )?;
 
         Ok(ConstrainedEpoch {
@@ -170,7 +169,7 @@ mod tests {
         bitmap: &[bool],
     ) -> ConstrainedEpoch {
         // convert to constraints
-        let prev_index = to_fr(&mut cs.ns(|| "prev index to fr"), prev_index).unwrap();
+        let prev_index = to_fr(&mut cs.ns(|| "prev index to fr"), Some(prev_index)).unwrap();
         let prev_validators = alloc_vec(cs, &pubkeys::<Bls12_377>(n_validators));
 
         // generate the update via the helper

--- a/crates/epoch-snark/src/lib.rs
+++ b/crates/epoch-snark/src/lib.rs
@@ -43,14 +43,14 @@ pub extern "C" fn encode_epoch_block_to_bytes(
         let added_public_keys = added_public_keys_ptrs
             .to_vec()
             .into_iter()
-            .map(|pk| unsafe { &*pk })
-            .collect::<Vec<&PublicKey>>();
+            .map(|pk| unsafe { &*pk }.clone())
+            .collect::<Vec<PublicKey>>();
 
         let mut encoded = EpochBlock::new(
             in_epoch_index as u16,
             in_maximum_non_signers as u32,
-            &aggregated_public_key,
-            &added_public_keys,
+            aggregated_public_key.clone(),
+            added_public_keys,
         )
         .encode_to_bytes()?;
         encoded.shrink_to_fit();


### PR DESCRIPTION
- Removes slices of references from the APIs. They make every datatype really awkward to work with and do not provide any significant advantage. Also, taking a reference and cloning inside is generally bad practice so I've removed that as well. It's better if the caller explicitly clones so that there's no hidden costs. This might mean that we have an allocation overhead in the FFI, but I recommend we worry about that later, when we actually test the FFI performance.
- The gadgets previously were not sufficiently equipped to handle being called during the parameter generation phase. We add a heuristic for getting inner booleans which says "if any of the inner variables is None, then assume we're in the setup phase". I think this is a fair assumption to make for our boolean constraint slices.