### PR TITLE
Adds tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "r1cs-std",
  "rand",
  "rand_xorshift",
+ "tracing",
 ]
 
 [[package]]
@@ -211,6 +212,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
 
 [[package]]
 name = "clap"
@@ -465,6 +477,8 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -597,6 +611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -837,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+
+[[package]]
 name = "regex"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +894,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 dependencies = [
  "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
 ]
 
 [[package]]
@@ -934,6 +975,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1018,6 +1068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1086,77 @@ checksum = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1721cc8cf7d770cc4257872507180f35a4797272f5962f24c806af9e7faf52ab"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
+dependencies = [
+ "quote 1.0.3",
+ "syn 1.0.16",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedebcf5813b02261d6bab3a12c6a8ae702580c0405a2e8ec16c3713caf14c20"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1050,6 +1182,12 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "vec_map"

--- a/crates/bls-crypto/src/curve/hash/try_and_increment.rs
+++ b/crates/bls-crypto/src/curve/hash/try_and_increment.rs
@@ -8,7 +8,7 @@ use crate::{
 use bench_utils::{end_timer, start_timer};
 use byteorder::WriteBytesExt;
 use hex;
-use log::debug;
+use log::trace;
 
 use algebra::{
     bytes::FromBytes,
@@ -160,7 +160,7 @@ impl<'a, H: XOF> TryAndIncrement<'a, H> {
             match get_point_from_x_g1::<P>(possible_x, greatest) {
                 None => continue,
                 Some(x) => {
-                    debug!(
+                    trace!(
                         "succeeded hashing \"{}\" to G1 in {} tries",
                         hex::encode(message),
                         c
@@ -228,7 +228,7 @@ impl<'a, H: XOF> HashToG2 for TryAndIncrement<'a, H> {
             match get_point_from_x::<P>(possible_x, greatest) {
                 None => continue,
                 Some(x) => {
-                    debug!(
+                    trace!(
                         "succeeded hashing \"{}\" to G2 in {} tries",
                         hex::encode(message),
                         c

--- a/crates/bls-gadgets/Cargo.toml
+++ b/crates/bls-gadgets/Cargo.toml
@@ -15,6 +15,7 @@ crypto-primitives = { git = "https://github.com/scipr-lab/zexe", default-feature
 # used only when exporting our test helpers to be used in the snark crate
 rand_xorshift = { version = "0.2", optional = true }
 rand = { version = "0.7" , optional = true }
+tracing = "0.1.13"
 
 [dev-dependencies]
 rand_xorshift = { version = "0.2" }

--- a/crates/bls-gadgets/src/bitmap.rs
+++ b/crates/bls-gadgets/src/bitmap.rs
@@ -6,7 +6,6 @@ use r1cs_std::{
     prelude::*,
     Assignment,
 };
-use tracing::{debug, error, info, span, warn, Level};
 
 /// Enforces that there are no more than `max_occurrences` of `value` (0 or 1)
 /// present in the provided bitmap

--- a/crates/bls-gadgets/src/bitmap.rs
+++ b/crates/bls-gadgets/src/bitmap.rs
@@ -6,6 +6,7 @@ use r1cs_std::{
     prelude::*,
     Assignment,
 };
+use tracing::{debug, error, info, span, warn, Level};
 
 /// Enforces that there are no more than `max_occurrences` of `value` (0 or 1)
 /// present in the provided bitmap

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -6,7 +6,7 @@ use r1cs_std::{
     groups::GroupGadget, pairing::PairingGadget, select::CondSelectGadget,
 };
 use std::marker::PhantomData;
-use tracing::{debug, error, info, span, trace, warn, Level};
+use tracing::{debug, span, Level};
 
 /// BLS Signature Verification Pairing Gadget.
 ///

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -6,7 +6,7 @@ use r1cs_std::{
     groups::GroupGadget, pairing::PairingGadget, select::CondSelectGadget,
 };
 use std::marker::PhantomData;
-use tracing::{debug, span, Level};
+use tracing::{debug, span, trace, Level};
 
 /// BLS Signature Verification Pairing Gadget.
 ///
@@ -43,7 +43,7 @@ where
         signature: &P::G1Gadget,
         maximum_non_signers: &FpGadget<F>,
     ) -> Result<(), SynthesisError> {
-        let span = span!(Level::TRACE, "BlsVerifyGadget");
+        let span = span!(Level::TRACE, "BlsVerifyGadget_verify");
         let _enter = span.enter();
         // Get the message hash and the aggregated public key based on the bitmap
         // and allowed number of non-signers
@@ -80,6 +80,7 @@ where
         message_hashes: &[P::G1Gadget],
         aggregated_signature: &P::G1Gadget,
     ) -> Result<(), SynthesisError> {
+        debug!("batch verifying BLS signature");
         let prepared_message_hashes = message_hashes
             .iter()
             .enumerate()
@@ -210,10 +211,10 @@ where
         message_hash: &P::G1Gadget,
         maximum_non_signers: &FpGadget<F>,
     ) -> Result<(P::G1PreparedGadget, P::G2PreparedGadget), SynthesisError> {
-        debug!("enforcing bitmap");
+        trace!("enforcing bitmap");
         enforce_maximum_occurrences_in_bitmap(&mut cs, signed_bitmap, maximum_non_signers, false)?;
 
-        debug!("preparing message hash and aggregated pubkey");
+        trace!("preparing message hash and aggregated pubkey");
         let prepared_message_hash =
             P::prepare_g1(cs.ns(|| "prepared message hash"), &message_hash)?;
         let prepared_aggregated_pk =
@@ -253,7 +254,7 @@ where
         g1: &[P::G1PreparedGadget],
         g2: &[P::G2PreparedGadget],
     ) -> Result<(), SynthesisError> {
-        debug!("enforcing BLS equation");
+        trace!("enforcing BLS equation");
         let bls_equation = P::product_of_pairings(cs.ns(|| "verify BLS signature"), g1, g2)?;
         let gt_one = &P::GTGadget::one(&mut cs.ns(|| "GT one"))?;
         bls_equation.enforce_equal(&mut cs.ns(|| "BLS equation is one"), gt_one)?;

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -87,7 +87,7 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
         counter: UInt8,
         message: &[UInt8],
     ) -> Result<(G1Gadget<Bls12_377_Parameters>, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
-        let span = span!(Level::TRACE, "enforcing_hash_to_group",);
+        let span = span!(Level::TRACE, "enforce_hash_to_group",);
         let _enter = span.enter();
 
         // combine the counter with the message
@@ -162,7 +162,7 @@ pub fn hash_to_bits<F: PrimeField, CS: ConstraintSystem<F>>(
 ) -> Result<Vec<Boolean>, SynthesisError> {
     let span = span!(
         Level::TRACE,
-        "hash_to_bits_gadget",
+        "hash_to_bits",
         hash_length,
         generate_constraints
     );
@@ -223,11 +223,11 @@ impl<P: Bls12Parameters> HashToGroupGadget<P> {
     // Receives the output of `HashToBitsGadget::hash_to_bits` in Little Endian
     // decodes the G1 point and then multiplies it by the curve's cofactor to
     // get the hash
-    pub fn hash_to_group<CS: ConstraintSystem<P::Fp>>(
+    fn hash_to_group<CS: ConstraintSystem<P::Fp>>(
         mut cs: CS,
         xof_bits: &[Boolean],
     ) -> Result<G1Gadget<P>, SynthesisError> {
-        let span = span!(Level::TRACE, "hash_to_group_gadget",);
+        let span = span!(Level::TRACE, "HashToGroupGadget",);
         let _enter = span.enter();
 
         trace!("getting G1 point from bits");
@@ -302,8 +302,6 @@ impl<P: Bls12Parameters> HashToGroupGadget<P> {
             cs.ns(|| "scale by cofactor"),
             &expected_point_before_cofactor,
         )?;
-
-        debug!("point has been hashed to G1");
 
         Ok(scaled_point)
     }

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -33,7 +33,7 @@ use crypto_primitives::{
     crh::bowe_hopwood::constraints::BoweHopwoodPedersenCRHGadget as BHHash, FixedLengthCRHGadget,
 };
 use r1cs_std::edwards_sw6::EdwardsSWGadget;
-use tracing::{debug, error, info, span, trace, warn, Level};
+use tracing::{debug, span, trace, Level};
 
 use crate::{bits_to_bytes, bytes_to_bits, constrain_bool, is_setup, YToBitGadget};
 
@@ -87,10 +87,7 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
         counter: UInt8,
         message: &[UInt8],
     ) -> Result<(G1Gadget<Bls12_377_Parameters>, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
-        let span = span!(
-            Level::TRACE,
-            "enforcing_hash_to_group",
-        );
+        let span = span!(Level::TRACE, "enforcing_hash_to_group",);
         let _enter = span.enter();
 
         // combine the counter with the message
@@ -230,10 +227,7 @@ impl<P: Bls12Parameters> HashToGroupGadget<P> {
         mut cs: CS,
         xof_bits: &[Boolean],
     ) -> Result<G1Gadget<P>, SynthesisError> {
-        let span = span!(
-            Level::TRACE,
-            "hash_to_group_gadget",
-        );
+        let span = span!(Level::TRACE, "hash_to_group_gadget",);
         let _enter = span.enter();
 
         trace!("getting G1 point from bits");

--- a/crates/epoch-snark/Cargo.toml
+++ b/crates/epoch-snark/Cargo.toml
@@ -16,9 +16,11 @@ groth16 = { git = "https://github.com/scipr-lab/zexe" }
 
 rand = "0.7" 
 byteorder = "1.3.2"
-log = "0.4.6"
+log = "0.4.8"
 blake2s_simd = "0.5.8"
 thiserror = "1.0.11"
+tracing-subscriber = "0.2.3"
+tracing = "0.1.13"
 
 [dev-dependencies]
 rand_xorshift = { version = "0.2" }

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -5,7 +5,17 @@ use std::env;
 mod fixtures;
 use fixtures::generate_test_data;
 
+use tracing_subscriber::{
+    filter::EnvFilter,
+    fmt::{time::ChronoUtc, Subscriber},
+};
+
 fn main() {
+    Subscriber::builder()
+        .with_timer(ChronoUtc::rfc3339())
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
     let rng = &mut rand::thread_rng();
     let mut args = env::args();
     args.next().unwrap(); // discard the program name

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -29,7 +29,7 @@ pub fn prove(
         num_validators,
     );
 
-    let span = span!(Level::TRACE, "proof_generation");
+    let span = span!(Level::TRACE, "prove");
     let _enter = span.enter();
 
     let composite_hasher = CompositeHasher::new().unwrap();

--- a/crates/epoch-snark/src/api/setup.rs
+++ b/crates/epoch-snark/src/api/setup.rs
@@ -13,6 +13,7 @@ use rand::Rng;
 use super::{BLSCurve, CPCurve, CPFrParams};
 
 use groth16::{generate_random_parameters, Parameters as Groth16Parameters, VerifyingKey};
+use tracing::{debug, error, info, span, warn, Level};
 
 type Result<T> = std::result::Result<T, SynthesisError>;
 
@@ -75,6 +76,14 @@ where
     F: FnOnce(HashToBits, &mut R) -> Result<Groth16Parameters<BLS>>,
     G: FnOnce(ValidatorSetUpdate<BLS>, &mut R) -> Result<Groth16Parameters<CP>>,
 {
+    info!(
+        "Generating parameters for {} validators and {} epochs",
+        num_validators, num_epochs
+    );
+
+    let span = span!(Level::TRACE, "setup");
+    let _enter = span.enter();
+
     let empty_hash_to_bits = HashToBits::empty::<CPFrParams>(num_epochs);
     let hash_to_bits = hash_to_bits_setup(empty_hash_to_bits, rng)?;
 

--- a/crates/epoch-snark/src/api/setup.rs
+++ b/crates/epoch-snark/src/api/setup.rs
@@ -84,9 +84,11 @@ where
     let span = span!(Level::TRACE, "setup");
     let _enter = span.enter();
 
+    info!("CRH->XOF");
     let empty_hash_to_bits = HashToBits::empty::<CPFrParams>(num_epochs);
     let hash_to_bits = hash_to_bits_setup(empty_hash_to_bits, rng)?;
 
+    info!("BLS");
     let empty_epochs = ValidatorSetUpdate::empty(
         num_validators,
         num_epochs,

--- a/crates/epoch-snark/src/api/verifier.rs
+++ b/crates/epoch-snark/src/api/verifier.rs
@@ -5,6 +5,7 @@ use crate::gadgets::pack;
 use groth16::{prepare_verifying_key, verify_proof, Proof, VerifyingKey};
 use r1cs_core::SynthesisError;
 use thiserror::Error;
+use tracing::info;
 
 #[derive(Debug, Error)]
 pub enum VerificationError {
@@ -23,6 +24,7 @@ pub fn verify(
     last_epoch: &EpochBlock,
     proof: Proof<CPCurve>,
 ) -> Result<(), VerificationError> {
+    info!("Verifying proof");
     // Hash the first-last block together
     let hash = hash_first_last_epoch_block(first_epoch, last_epoch)?;
     // packs them

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -70,7 +70,6 @@ impl EpochData<Bls12_377> {
         let (message_hash, crh_bits, xof_bits) =
             Self::hash_bits_to_g1(&mut cs.ns(|| "hash epoch to g1 bits"), &bits)?;
 
-        debug!("constrained");
         Ok(ConstrainedEpochData {
             bits,
             index,

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -18,7 +18,7 @@ use bls_crypto::{
 use bls_gadgets::{is_setup, HashToGroupGadget};
 
 use super::{fr_to_bits, g2_to_bits, to_fr};
-use tracing::{debug, span, Level};
+use tracing::{span, trace, Level};
 
 type FrGadget = FpGadget<Fr>;
 

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -18,6 +18,7 @@ use bls_crypto::{
 use bls_gadgets::{is_setup, HashToGroupGadget};
 
 use super::{fr_to_bits, g2_to_bits, to_fr};
+use tracing::{debug, span, Level};
 
 type FrGadget = FpGadget<Fr>;
 
@@ -60,6 +61,8 @@ impl EpochData<Bls12_377> {
         cs: &mut CS,
         previous_index: &FrGadget,
     ) -> Result<ConstrainedEpochData, SynthesisError> {
+        let span = span!(Level::TRACE, "EpochData");
+        let _enter = span.enter();
         let (bits, index, maximum_non_signers, pubkeys) = self.to_bits(cs)?;
         Self::enforce_next_epoch(&mut cs.ns(|| "enforce next epoch"), previous_index, &index)?;
 
@@ -67,6 +70,7 @@ impl EpochData<Bls12_377> {
         let (message_hash, crh_bits, xof_bits) =
             Self::hash_bits_to_g1(&mut cs.ns(|| "hash epoch to g1 bits"), &bits)?;
 
+        debug!("constrained");
         Ok(ConstrainedEpochData {
             bits,
             index,
@@ -119,6 +123,7 @@ impl EpochData<Bls12_377> {
         previous_index: &FrGadget,
         index: &FrGadget,
     ) -> Result<(), SynthesisError> {
+        trace!("enforcing next epoch");
         let previous_plus_one =
             previous_index.add_constant(cs.ns(|| "previous plus_one"), &Fr::one())?;
         index.enforce_equal(cs.ns(|| "index enforce equal"), &previous_plus_one)?;
@@ -131,6 +136,7 @@ impl EpochData<Bls12_377> {
         cs: &mut CS,
         epoch_bits: &[Boolean],
     ) -> Result<(G1Gadget, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
+        trace!("hashing epoch to g1");
         // Reverse to LE
         let mut epoch_bits = epoch_bits.to_vec();
         epoch_bits.reverse();

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -192,6 +192,7 @@ impl ValidatorSetUpdate<Bls12_377> {
                 last_epoch_bits = constrained_epoch.bits;
                 last_epoch_bits.extend_from_slice(&last_apk_bits);
             }
+            debug!("epoch {} constrained", i);
         }
 
         debug!("intermediate epochs verified");

--- a/crates/epoch-snark/src/gadgets/hash_to_bits.rs
+++ b/crates/epoch-snark/src/gadgets/hash_to_bits.rs
@@ -7,7 +7,7 @@ use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 use super::{constrain_bool, MultipackGadget};
 use bls_crypto::bls::keys::SIG_DOMAIN;
 use bls_gadgets::hash_to_bits;
-use tracing::{debug, info, span, Level};
+use tracing::{debug, info, span, trace, Level};
 
 #[derive(Clone)]
 /// Gadget which
@@ -34,11 +34,13 @@ impl HashToBits {
 }
 
 impl ConstraintSynthesizer<Fr> for HashToBits {
+    #[allow(clippy::cognitive_complexity)] // false positive triggered by the info!("generating constraints") log
     fn generate_constraints<CS: ConstraintSystem<Fr>>(
         self,
         cs: &mut CS,
     ) -> Result<(), SynthesisError> {
         let span = span!(Level::TRACE, "HashToBits");
+        info!("generating constraints");
         let _enter = span.enter();
         let mut personalization = [0; 8];
         personalization.copy_from_slice(SIG_DOMAIN);
@@ -46,7 +48,7 @@ impl ConstraintSynthesizer<Fr> for HashToBits {
         let mut all_bits = vec![];
         let mut xof_bits = vec![];
         for (i, message_bits) in self.message_bits.iter().enumerate() {
-            debug!(epoch = i, "hashing to bits");
+            trace!(epoch = i, "hashing to bits");
             let bits = constrain_bool(&mut cs.ns(|| i.to_string()), &message_bits)?;
             let hash = hash_to_bits(
                 cs.ns(|| format!("{}: hash to bits", i)),

--- a/crates/epoch-snark/src/gadgets/pack.rs
+++ b/crates/epoch-snark/src/gadgets/pack.rs
@@ -2,6 +2,7 @@ use algebra::{BigInteger, FpParameters, PrimeField};
 use bls_gadgets::is_setup;
 use r1cs_core::SynthesisError;
 use r1cs_std::{fields::fp::FpGadget, prelude::*, Assignment};
+use tracing::{debug, error, info, span, trace, warn, Level};
 
 pub struct MultipackGadget;
 
@@ -12,9 +13,12 @@ impl MultipackGadget {
         target_capacity: usize,
         should_alloc_input: bool,
     ) -> Result<Vec<FpGadget<F>>, SynthesisError> {
+        let span = span!(Level::TRACE, "multipack_gadget");
+        let _enter = span.enter();
         let mut packed = vec![];
         let fp_chunks = bits.chunks(target_capacity);
         for (i, chunk) in fp_chunks.enumerate() {
+            trace!(iteration = i);
             let alloc = if should_alloc_input {
                 FpGadget::<F>::alloc_input
             } else {

--- a/crates/epoch-snark/src/gadgets/pack.rs
+++ b/crates/epoch-snark/src/gadgets/pack.rs
@@ -2,7 +2,7 @@ use algebra::{BigInteger, FpParameters, PrimeField};
 use bls_gadgets::is_setup;
 use r1cs_core::SynthesisError;
 use r1cs_std::{fields::fp::FpGadget, prelude::*, Assignment};
-use tracing::{debug, error, info, span, trace, warn, Level};
+use tracing::{span, trace, Level};
 
 pub struct MultipackGadget;
 

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -8,7 +8,7 @@ use r1cs_std::{
 
 use super::{constrain_bool, EpochData};
 use bls_gadgets::BlsVerifyGadget;
-use tracing::{debug, span, Level};
+use tracing::{span, Level};
 
 // Instantiate the BLS Verification gadget
 

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -86,7 +86,6 @@ impl SingleUpdate<Bls12_377> {
                 &previous_max_non_signers,
             )?;
 
-        debug!("constrained");
         Ok(ConstrainedEpoch {
             new_pubkeys: epoch_data.pubkeys,
             new_max_non_signers: epoch_data.maximum_non_signers,

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -8,6 +8,7 @@ use r1cs_std::{
 
 use super::{constrain_bool, EpochData};
 use bls_gadgets::BlsVerifyGadget;
+use tracing::{debug, span, Level};
 
 // Instantiate the BLS Verification gadget
 
@@ -61,6 +62,8 @@ impl SingleUpdate<Bls12_377> {
         previous_max_non_signers: &FrGadget,
         num_validators: u32,
     ) -> Result<ConstrainedEpoch, SynthesisError> {
+        let span = span!(Level::TRACE, "SingleUpdate");
+        let _enter = span.enter();
         // the number of validators across all epochs must be consistent
         assert_eq!(num_validators as usize, self.epoch_data.public_keys.len());
 
@@ -83,6 +86,7 @@ impl SingleUpdate<Bls12_377> {
                 &previous_max_non_signers,
             )?;
 
+        debug!("constrained");
         Ok(ConstrainedEpoch {
             new_pubkeys: epoch_data.pubkeys,
             new_max_non_signers: epoch_data.maximum_non_signers,


### PR DESCRIPTION
As title, using the [tracing](https://github.com/tokio-rs/tracing) crate.

We use `info` logs for the top level API calls, and spanned `debug` and `trace` logs for lower level information (`span` basically groups together all calls within that scope)

Example log below
[tracing.log](https://github.com/celo-org/bls-zexe/files/4337622/tracing.log)
![image](https://user-images.githubusercontent.com/17802178/76748865-31f97f00-6784-11ea-9860-6215690a9f9d.png)
