### PR TITLE
Optionally hash in SW6

### DIFF
--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -86,6 +86,7 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
         cs: &mut CS,
         counter: UInt8,
         message: &[UInt8],
+        generate_constraints: bool,
     ) -> Result<(G1Gadget<Bls12_377_Parameters>, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
         let span = span!(Level::TRACE, "enforce_hash_to_group",);
         let _enter = span.enter();
@@ -106,7 +107,7 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
             &crh_bits,
             512,
             personalization,
-            false,
+            generate_constraints,
         )?;
 
         let hash = Self::hash_to_group(cs.ns(|| "hash to group"), &xof_bits)?;
@@ -379,6 +380,7 @@ mod test {
             &mut cs.ns(|| "hash to group"),
             counter,
             &input,
+            false,
         )
         .unwrap()
         .0;

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -86,7 +86,7 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
         cs: &mut CS,
         counter: UInt8,
         message: &[UInt8],
-        generate_constraints: bool,
+        generate_constraints_for_hash: bool,
     ) -> Result<(G1Gadget<Bls12_377_Parameters>, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
         let span = span!(Level::TRACE, "enforce_hash_to_group",);
         let _enter = span.enter();
@@ -107,7 +107,7 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
             &crh_bits,
             512,
             personalization,
-            generate_constraints,
+            generate_constraints_for_hash,
         )?;
 
         let hash = Self::hash_to_group(cs.ns(|| "hash to group"), &xof_bits)?;
@@ -159,16 +159,16 @@ pub fn hash_to_bits<F: PrimeField, CS: ConstraintSystem<F>>(
     message: &[Boolean],
     hash_length: u16,
     personalization: [u8; 8],
-    generate_constraints: bool,
+    generate_constraints_for_hash: bool,
 ) -> Result<Vec<Boolean>, SynthesisError> {
     let span = span!(
         Level::TRACE,
         "hash_to_bits",
         hash_length,
-        generate_constraints
+        generate_constraints_for_hash
     );
     let _enter = span.enter();
-    let xof_bits = if generate_constraints {
+    let xof_bits = if generate_constraints_for_hash {
         trace!("generating hash with constraints");
         // Reverse the message to LE
         let mut message = message.to_vec();

--- a/crates/epoch-snark/Cargo.toml
+++ b/crates/epoch-snark/Cargo.toml
@@ -34,3 +34,7 @@ crate-type = ["lib", "staticlib"]
 [[example]]
 name = "proof"
 path = "examples/proof.rs"
+
+[[example]]
+name = "constraints"
+path = "examples/constraints.rs"

--- a/crates/epoch-snark/examples/constraints.rs
+++ b/crates/epoch-snark/examples/constraints.rs
@@ -1,0 +1,75 @@
+use algebra::{bls12_377::G1Projective, Zero};
+use epoch_snark::{
+    api::{prover, BLSCurve, CPFrParams},
+    gadgets::{HashToBits, ValidatorSetUpdate},
+};
+use groth16::generate_random_parameters;
+use r1cs_core::ConstraintSynthesizer;
+use r1cs_std::test_constraint_system::TestConstraintSystem;
+use std::env;
+
+#[path = "../tests/fixtures.rs"]
+mod fixtures;
+use fixtures::generate_test_data;
+
+fn main() {
+    let rng = &mut rand::thread_rng();
+    let mut args = env::args();
+    args.next().unwrap(); // discard the program name
+    let num_validators = args
+        .next()
+        .expect("num validators was expected")
+        .parse()
+        .expect("NaN");
+    let num_epochs = args
+        .next()
+        .expect("num epochs was expected")
+        .parse()
+        .expect("NaN");
+    let hashes_in_bls12_377: bool = args
+        .next()
+        .expect("expected flag for generating or not constraints inside BLS12_377")
+        .parse()
+        .expect("not a bool");
+    let faults = (num_validators - 1) / 3;
+
+    // Make a random initialization of the circuit
+    let (first_epoch, transitions, _) = generate_test_data(num_validators, faults, num_epochs);
+
+    // Trusted setup for the HashToBits circuit if required
+    let hash_helper = if hashes_in_bls12_377 {
+        let empty_hash_to_bits = HashToBits::empty::<CPFrParams>(num_epochs);
+        let params = generate_random_parameters(empty_hash_to_bits, rng).unwrap();
+        let helper = prover::generate_hash_helper(&params, &transitions).unwrap();
+        Some(helper)
+    } else {
+        None
+    };
+
+    let asig = transitions.iter().fold(G1Projective::zero(), |acc, epoch| {
+        acc + epoch.aggregate_signature.get_sig()
+    });
+    let epochs = transitions
+        .iter()
+        .map(|transition| prover::to_update(transition))
+        .collect::<Vec<_>>();
+    let circuit = ValidatorSetUpdate::<BLSCurve> {
+        initial_epoch: prover::to_epoch_data(&first_epoch),
+        epochs,
+        aggregated_signature: Some(asig),
+        num_validators: num_validators as u32,
+        hash_helper,
+    };
+
+    // generate test constraints and log them
+    let mut cs = TestConstraintSystem::new();
+    circuit.generate_constraints(&mut cs).unwrap();
+
+    println!(
+        "Number of constraints for {} epochs ({} validators, hashes in BLS12-377 {}): {}",
+        num_epochs,
+        num_validators,
+        hashes_in_bls12_377,
+        cs.num_constraints()
+    )
+}

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -31,23 +31,17 @@ fn main() {
         .expect("num epochs was expected")
         .parse()
         .expect("NaN");
-    let generate_constraints: bool = args
+    let hashes_in_bls12_377: bool = args
         .next()
-        .expect("expected flag for generating or not constraints inside SW6")
+        .expect("expected flag for generating or not constraints inside BLS12_377")
         .parse()
         .expect("not a bool");
     let faults = (num_validators - 1) / 3;
 
     // Trusted setup
     let time = start_timer!(|| "Trusted setup");
-    let params = setup::trusted_setup(
-        num_validators,
-        num_epochs,
-        faults,
-        rng,
-        generate_constraints,
-    )
-    .unwrap();
+    let params =
+        setup::trusted_setup(num_validators, num_epochs, faults, rng, hashes_in_bls12_377).unwrap();
     end_timer!(time);
 
     // Create the state to be proven (first - last and in between)

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -57,19 +57,12 @@ fn main() {
 
     // Prover generates the proof given the params
     let time = start_timer!(|| "Generate proof");
-    let proof = prover::prove(
-        &params,
-        num_validators as u32,
-        &first_epoch,
-        &transitions,
-        generate_constraints,
-    )
-    .unwrap();
+    let proof = prover::prove(&params, num_validators as u32, &first_epoch, &transitions).unwrap();
     end_timer!(time);
 
     // Verifier checks the proof
     let time = start_timer!(|| "Verify proof");
-    let res = verifier::verify(params.vk().0, &first_epoch, &last_epoch, &proof);
+    let res = verifier::verify(&params.epochs.vk, &first_epoch, &last_epoch, &proof);
     end_timer!(time);
     assert!(res.is_ok());
 }

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -31,11 +31,23 @@ fn main() {
         .expect("num epochs was expected")
         .parse()
         .expect("NaN");
+    let generate_constraints: bool = args
+        .next()
+        .expect("expected flag for generating or not constraints inside SW6")
+        .parse()
+        .expect("not a bool");
     let faults = (num_validators - 1) / 3;
 
     // Trusted setup
     let time = start_timer!(|| "Trusted setup");
-    let params = setup::trusted_setup(num_validators, num_epochs, faults, rng).unwrap();
+    let params = setup::trusted_setup(
+        num_validators,
+        num_epochs,
+        faults,
+        rng,
+        generate_constraints,
+    )
+    .unwrap();
     end_timer!(time);
 
     // Create the state to be proven (first - last and in between)
@@ -45,7 +57,14 @@ fn main() {
 
     // Prover generates the proof given the params
     let time = start_timer!(|| "Generate proof");
-    let proof = prover::prove(&params, num_validators as u32, &first_epoch, &transitions).unwrap();
+    let proof = prover::prove(
+        &params,
+        num_validators as u32,
+        &first_epoch,
+        &transitions,
+        generate_constraints,
+    )
+    .unwrap();
     end_timer!(time);
 
     // Verifier checks the proof

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -2,7 +2,11 @@ use super::{BLSCurve, CPCurve, Parameters};
 use crate::{
     api::CPField,
     epoch_block::{EpochBlock, EpochTransition},
-    gadgets::{single_update::SingleUpdate, EpochData, HashToBits, ValidatorSetUpdate},
+    gadgets::{
+        epochs::{HashToBitsHelper, ValidatorSetUpdate},
+        single_update::SingleUpdate,
+        EpochData, HashToBits,
+    },
 };
 use bls_crypto::{
     bls::keys::SIG_DOMAIN, curve::hash::try_and_increment::TryAndIncrement, hash::composite::CRH,
@@ -79,9 +83,10 @@ pub fn prove(
         epochs,
         aggregated_signature: Some(asig),
         num_validators,
-        proof: hash_proof,
-        verifying_key: parameters.vk().1.clone(),
-        generate_constraints,
+        hash_helper: Some(HashToBitsHelper {
+            proof: hash_proof,
+            verifying_key: parameters.vk().1.clone(),
+        }),
     };
     info!("BLS");
     let bls_proof = create_proof_no_zk(circuit, &parameters.epochs)?;

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -68,7 +68,7 @@ pub fn prove(
 }
 
 /// Helper which creates the hashproof inside BLS12-377
-fn generate_hash_helper(
+pub fn generate_hash_helper(
     params: &Groth16Parameters<BLSCurve>,
     transitions: &[EpochTransition],
 ) -> Result<HashToBitsHelper<BLSCurve>, SynthesisError> {
@@ -110,7 +110,7 @@ fn generate_hash_helper(
     })
 }
 
-fn to_epoch_data(block: &EpochBlock) -> EpochData<BLSCurve> {
+pub fn to_epoch_data(block: &EpochBlock) -> EpochData<BLSCurve> {
     EpochData {
         index: Some(block.index),
         maximum_non_signers: block.maximum_non_signers,
@@ -122,7 +122,7 @@ fn to_epoch_data(block: &EpochBlock) -> EpochData<BLSCurve> {
     }
 }
 
-fn to_update(transition: &EpochTransition) -> SingleUpdate<BLSCurve> {
+pub fn to_update(transition: &EpochTransition) -> SingleUpdate<BLSCurve> {
     SingleUpdate {
         epoch_data: to_epoch_data(&transition.block),
         signed_bitmap: transition

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -21,6 +21,7 @@ pub fn prove(
     num_validators: u32,
     initial_epoch: &EpochBlock,
     transitions: &[EpochTransition],
+    generate_constraints: bool,
 ) -> Result<Groth16Proof<CPCurve>, SynthesisError> {
     info!(
         "Generating proof for {} epochs (first epoch: {}, {} validators per epoch)",
@@ -60,6 +61,8 @@ pub fn prove(
         epochs.push(to_update(transition));
     }
 
+    // If generate constraint sis true, generate both proofs, otherwise just one
+
     // Generate proof of correct calculation of the CRH->Blake hashes
     // to make Hash to G1 cheaper
     let circuit = HashToBits { message_bits };
@@ -78,6 +81,7 @@ pub fn prove(
         num_validators,
         proof: hash_proof,
         verifying_key: parameters.vk().1.clone(),
+        generate_constraints,
     };
     info!("BLS");
     let bls_proof = create_proof_no_zk(circuit, &parameters.epochs)?;

--- a/crates/epoch-snark/src/api/setup.rs
+++ b/crates/epoch-snark/src/api/setup.rs
@@ -96,8 +96,7 @@ where
         num_validators,
         num_epochs,
         maximum_non_signers,
-        hash_to_bits.vk.clone(),
-        generate_constraints,
+        Some(hash_to_bits.vk.clone()),
     );
     let epochs = validator_setup_fn(empty_epochs, rng)?;
 

--- a/crates/epoch-snark/src/api/setup.rs
+++ b/crates/epoch-snark/src/api/setup.rs
@@ -35,6 +35,7 @@ pub fn trusted_setup<R: Rng>(
     num_epochs: usize,
     maximum_non_signers: usize,
     rng: &mut R,
+    generate_constraints: bool,
 ) -> Result<Parameters<CPCurve, BLSCurve>> {
     setup(
         num_validators,
@@ -43,6 +44,7 @@ pub fn trusted_setup<R: Rng>(
         rng,
         |c, rng| generate_random_parameters(c, rng),
         |c, rng| generate_random_parameters(c, rng),
+        generate_constraints,
     )
 }
 
@@ -52,7 +54,7 @@ mod tests {
     #[test]
     fn runs_setup() {
         let rng = &mut rand::thread_rng();
-        assert!(trusted_setup(3, 2, 1, rng).is_ok())
+        assert!(trusted_setup(3, 2, 1, rng, false).is_ok())
     }
 }
 
@@ -68,6 +70,7 @@ fn setup<CP, BLS, F, G, R>(
     rng: &mut R,
     hash_to_bits_setup: F,
     validator_setup_fn: G,
+    generate_constraints: bool,
 ) -> Result<Parameters<CP, BLS>>
 where
     CP: PairingEngine,
@@ -94,6 +97,7 @@ where
         num_epochs,
         maximum_non_signers,
         hash_to_bits.vk.clone(),
+        generate_constraints,
     );
     let epochs = validator_setup_fn(empty_epochs, rng)?;
 

--- a/crates/epoch-snark/src/api/setup.rs
+++ b/crates/epoch-snark/src/api/setup.rs
@@ -81,8 +81,8 @@ where
     let span = span!(Level::TRACE, "setup");
     let _enter = span.enter();
 
-    info!("CRH->XOF");
     let (vk, hash_to_bits) = if generate_constraints {
+        info!("CRH->XOF");
         let empty_hash_to_bits = HashToBits::empty::<CPFrParams>(num_epochs);
         let hash_to_bits = hash_to_bits_setup(empty_hash_to_bits, rng)?;
         (Some(hash_to_bits.vk.clone()), Some(hash_to_bits))

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -60,6 +60,7 @@ impl EpochData<Bls12_377> {
         &self,
         cs: &mut CS,
         previous_index: &FrGadget,
+        generate_constraints: bool,
     ) -> Result<ConstrainedEpochData, SynthesisError> {
         let span = span!(Level::TRACE, "EpochData");
         let _enter = span.enter();
@@ -67,8 +68,11 @@ impl EpochData<Bls12_377> {
         Self::enforce_next_epoch(&mut cs.ns(|| "enforce next epoch"), previous_index, &index)?;
 
         // Hash to G1
-        let (message_hash, crh_bits, xof_bits) =
-            Self::hash_bits_to_g1(&mut cs.ns(|| "hash epoch to g1 bits"), &bits)?;
+        let (message_hash, crh_bits, xof_bits) = Self::hash_bits_to_g1(
+            &mut cs.ns(|| "hash epoch to g1 bits"),
+            &bits,
+            generate_constraints,
+        )?;
 
         Ok(ConstrainedEpochData {
             bits,
@@ -134,6 +138,7 @@ impl EpochData<Bls12_377> {
     fn hash_bits_to_g1<CS: ConstraintSystem<Fr>>(
         cs: &mut CS,
         epoch_bits: &[Boolean],
+        generate_constraints: bool,
     ) -> Result<(G1Gadget, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
         trace!("hashing epoch to g1");
         // Reverse to LE
@@ -176,6 +181,7 @@ impl EpochData<Bls12_377> {
             &mut cs.ns(|| "hash to group"),
             counter_var,
             &input_bytes_var,
+            generate_constraints,
         )
     }
 }
@@ -211,7 +217,7 @@ mod tests {
         let mut cs = TestConstraintSystem::<Fr>::new();
         let index = to_fr(&mut cs.ns(|| "index"), Some(9u32)).unwrap();
         epoch
-            .constrain(&mut cs.ns(|| "constraint"), &index)
+            .constrain(&mut cs.ns(|| "constraint"), &index, false)
             .unwrap();
         assert!(cs.is_satisfied());
     }
@@ -237,7 +243,7 @@ mod tests {
         // compare it with the one calculated in the circuit from its bytes
         let mut cs = TestConstraintSystem::<Fr>::new();
         let bits = epoch.to_bits(&mut cs.ns(|| "epoch2bits")).unwrap().0;
-        let ret = EpochData::hash_bits_to_g1(&mut cs.ns(|| "hash epoch bits"), &bits).unwrap();
+        let ret = EpochData::hash_bits_to_g1(&mut cs.ns(|| "hash epoch bits"), &bits, false).unwrap();
         assert_eq!(ret.0.get_value().unwrap(), hash);
     }
 

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -243,7 +243,8 @@ mod tests {
         // compare it with the one calculated in the circuit from its bytes
         let mut cs = TestConstraintSystem::<Fr>::new();
         let bits = epoch.to_bits(&mut cs.ns(|| "epoch2bits")).unwrap().0;
-        let ret = EpochData::hash_bits_to_g1(&mut cs.ns(|| "hash epoch bits"), &bits, false).unwrap();
+        let ret =
+            EpochData::hash_bits_to_g1(&mut cs.ns(|| "hash epoch bits"), &bits, false).unwrap();
         assert_eq!(ret.0.get_value().unwrap(), hash);
     }
 

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -60,7 +60,7 @@ impl EpochData<Bls12_377> {
         &self,
         cs: &mut CS,
         previous_index: &FrGadget,
-        generate_constraints: bool,
+        generate_constraints_for_hash: bool,
     ) -> Result<ConstrainedEpochData, SynthesisError> {
         let span = span!(Level::TRACE, "EpochData");
         let _enter = span.enter();
@@ -71,7 +71,7 @@ impl EpochData<Bls12_377> {
         let (message_hash, crh_bits, xof_bits) = Self::hash_bits_to_g1(
             &mut cs.ns(|| "hash epoch to g1 bits"),
             &bits,
-            generate_constraints,
+            generate_constraints_for_hash,
         )?;
 
         Ok(ConstrainedEpochData {
@@ -138,7 +138,7 @@ impl EpochData<Bls12_377> {
     fn hash_bits_to_g1<CS: ConstraintSystem<Fr>>(
         cs: &mut CS,
         epoch_bits: &[Boolean],
-        generate_constraints: bool,
+        generate_constraints_for_hash: bool,
     ) -> Result<(G1Gadget, Vec<Boolean>, Vec<Boolean>), SynthesisError> {
         trace!("hashing epoch to g1");
         // Reverse to LE
@@ -181,7 +181,7 @@ impl EpochData<Bls12_377> {
             &mut cs.ns(|| "hash to group"),
             counter_var,
             &input_bytes_var,
-            generate_constraints,
+            generate_constraints_for_hash,
         )
     }
 }

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -37,6 +37,8 @@ pub struct ValidatorSetUpdate<E: PairingEngine> {
     pub proof: Proof<E>,
     /// The VK produced by the trusted setup
     pub verifying_key: VerifyingKey<E>,
+    /// Flag which toggles generating constraints in SW6
+    pub generate_constraints: bool,
 }
 
 impl<E: PairingEngine> ValidatorSetUpdate<E> {
@@ -45,6 +47,7 @@ impl<E: PairingEngine> ValidatorSetUpdate<E> {
         num_epochs: usize,
         maximum_non_signers: usize,
         vk: VerifyingKey<E>,
+        generate_constraints: bool,
     ) -> Self {
         let empty_update = SingleUpdate::empty(num_validators, maximum_non_signers);
         let empty_hash_proof = Proof::<E>::default();
@@ -56,6 +59,7 @@ impl<E: PairingEngine> ValidatorSetUpdate<E> {
             aggregated_signature: None,
             proof: empty_hash_proof,
             verifying_key: vk,
+            generate_constraints,
         }
     }
 }
@@ -168,6 +172,7 @@ impl ValidatorSetUpdate<Bls12_377> {
                 &previous_epoch_index,
                 &previous_max_non_signers,
                 self.num_validators,
+                self.generate_constraints,
             )?;
 
             // Update the pubkeys for the next iteration
@@ -313,6 +318,7 @@ mod tests {
                 aggregated_signature: Some(aggregated_signature),
                 proof,
                 verifying_key: vk,
+                generate_constraints: false,
             };
 
             let mut cs = TestConstraintSystem::<Fr>::new();

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -33,12 +33,18 @@ pub struct ValidatorSetUpdate<E: PairingEngine> {
     pub epochs: Vec<SingleUpdate<E>>,
     /// The aggregated signature of all the validators over all the epoch changes
     pub aggregated_signature: Option<E::G1Projective>,
+    /// The optional hash to bits proof data. If provided, the circuit will not
+    /// constrain the inner CRH->XOF hashes in SW6 and instead it will be verified
+    /// via this proof
+    pub hash_helper: Option<HashToBitsHelper<E>>,
+}
+
+#[derive(Clone)]
+pub struct HashToBitsHelper<E: PairingEngine> {
     /// The Groth16 proof satisfying the statement
     pub proof: Proof<E>,
     /// The VK produced by the trusted setup
     pub verifying_key: VerifyingKey<E>,
-    /// Flag which toggles generating constraints in SW6
-    pub generate_constraints: bool,
 }
 
 impl<E: PairingEngine> ValidatorSetUpdate<E> {
@@ -46,20 +52,20 @@ impl<E: PairingEngine> ValidatorSetUpdate<E> {
         num_validators: usize,
         num_epochs: usize,
         maximum_non_signers: usize,
-        vk: VerifyingKey<E>,
-        generate_constraints: bool,
+        vk: Option<VerifyingKey<E>>,
     ) -> Self {
         let empty_update = SingleUpdate::empty(num_validators, maximum_non_signers);
-        let empty_hash_proof = Proof::<E>::default();
+        let hash_helper = vk.map(|vk| HashToBitsHelper {
+            proof: Proof::<E>::default(),
+            verifying_key: vk,
+        });
 
         ValidatorSetUpdate {
             initial_epoch: EpochData::empty(num_validators, maximum_non_signers),
             num_validators: num_validators as u32,
             epochs: vec![empty_update; num_epochs],
             aggregated_signature: None,
-            proof: empty_hash_proof,
-            verifying_key: vk,
-            generate_constraints,
+            hash_helper,
         }
     }
 }
@@ -75,11 +81,8 @@ impl ConstraintSynthesizer<Fr> for ValidatorSetUpdate<Bls12_377> {
         let _enter = span.enter();
         info!("generating constraints");
         let proof_of_compression = self.enforce(&mut cs.ns(|| "check signature"))?;
-        proof_of_compression.compress_public_inputs(
-            &mut cs.ns(|| "compress public inputs"),
-            &self.proof,
-            &self.verifying_key,
-        )?;
+        proof_of_compression
+            .compress_public_inputs(&mut cs.ns(|| "compress public inputs"), self.hash_helper)?;
 
         info!("constraints generated");
 
@@ -172,7 +175,7 @@ impl ValidatorSetUpdate<Bls12_377> {
                 &previous_epoch_index,
                 &previous_max_non_signers,
                 self.num_validators,
-                self.generate_constraints,
+                self.hash_helper.is_none(), // generate constraints if no helper was provided
             )?;
 
             // Update the pubkeys for the next iteration
@@ -309,16 +312,12 @@ mod tests {
             let asigs = sign_batch::<Bls12_377>(&signers_filtered, &epoch_hashes);
             let aggregated_signature = sum(&asigs);
 
-            let proof = Proof::default();
-            let vk = VerifyingKey::default();
             let valset = ValidatorSetUpdate::<Curve> {
                 initial_epoch,
                 epochs,
                 num_validators,
                 aggregated_signature: Some(aggregated_signature),
-                proof,
-                verifying_key: vk,
-                generate_constraints: false,
+                hash_helper: None,
             };
 
             let mut cs = TestConstraintSystem::<Fr>::new();

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -33,9 +33,9 @@ pub struct ValidatorSetUpdate<E: PairingEngine> {
     pub epochs: Vec<SingleUpdate<E>>,
     /// The aggregated signature of all the validators over all the epoch changes
     pub aggregated_signature: Option<E::G1Projective>,
-    /// The optional hash to bits proof data. If provided, the circuit will not
+    /// The optional hash to bits proof data. If provided, the circuit **will not**
     /// constrain the inner CRH->XOF hashes in SW6 and instead it will be verified
-    /// via this proof
+    /// via the helper's proof which is in BLS12-377.
     pub hash_helper: Option<HashToBitsHelper<E>>,
 }
 
@@ -175,7 +175,7 @@ impl ValidatorSetUpdate<Bls12_377> {
                 &previous_epoch_index,
                 &previous_max_non_signers,
                 self.num_validators,
-                self.hash_helper.is_none(), // generate constraints if no helper was provided
+                self.hash_helper.is_none(), // generate constraints in SW6 if no helper was provided
             )?;
 
             // Update the pubkeys for the next iteration

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -12,7 +12,7 @@ pub use pack::MultipackGadget;
 mod proof_of_compression;
 pub use proof_of_compression::ProofOfCompression;
 
-mod epochs;
+pub mod epochs;
 pub use epochs::ValidatorSetUpdate;
 
 // some helpers

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -61,6 +61,7 @@ impl SingleUpdate<Bls12_377> {
         previous_epoch_index: &FrGadget,
         previous_max_non_signers: &FrGadget,
         num_validators: u32,
+        generate_constraints: bool,
     ) -> Result<ConstrainedEpoch, SynthesisError> {
         let span = span!(Level::TRACE, "SingleUpdate");
         let _enter = span.enter();
@@ -68,9 +69,11 @@ impl SingleUpdate<Bls12_377> {
         assert_eq!(num_validators as usize, self.epoch_data.public_keys.len());
 
         // Get the constrained epoch data
-        let epoch_data = self
-            .epoch_data
-            .constrain(&mut cs.ns(|| "constrain"), previous_epoch_index)?;
+        let epoch_data = self.epoch_data.constrain(
+            &mut cs.ns(|| "constrain"),
+            previous_epoch_index,
+            generate_constraints,
+        )?;
 
         // convert the bitmap to constraints
         let signed_bitmap = constrain_bool(&mut cs.ns(|| "signed bitmap"), &self.signed_bitmap)?;
@@ -197,6 +200,7 @@ mod tests {
                 &prev_index,
                 &prev_max_non_signers,
                 prev_n_validators as u32,
+                false,
             )
             .unwrap()
     }

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -61,7 +61,7 @@ impl SingleUpdate<Bls12_377> {
         previous_epoch_index: &FrGadget,
         previous_max_non_signers: &FrGadget,
         num_validators: u32,
-        generate_constraints: bool,
+        generate_constraints_for_hash: bool,
     ) -> Result<ConstrainedEpoch, SynthesisError> {
         let span = span!(Level::TRACE, "SingleUpdate");
         let _enter = span.enter();
@@ -72,7 +72,7 @@ impl SingleUpdate<Bls12_377> {
         let epoch_data = self.epoch_data.constrain(
             &mut cs.ns(|| "constrain"),
             previous_epoch_index,
-            generate_constraints,
+            generate_constraints_for_hash,
         )?;
 
         // convert the bitmap to constraints

--- a/crates/epoch-snark/tests/e2e.rs
+++ b/crates/epoch-snark/tests/e2e.rs
@@ -12,8 +12,17 @@ fn prover_verifier_groth16() {
     let faults = 1;
     let num_validators = 3 * faults + 1;
 
+    let generate_constraints = false;
+
     // Trusted setup
-    let params = setup::trusted_setup(num_validators, num_transitions, faults, rng).unwrap();
+    let params = setup::trusted_setup(
+        num_validators,
+        num_transitions,
+        faults,
+        rng,
+        generate_constraints,
+    )
+    .unwrap();
 
     // Create the state to be proven (first epoch + `num_transitions` transitions.
     // Note: This is all data which should be fetched via the Celo blockchain
@@ -21,7 +30,14 @@ fn prover_verifier_groth16() {
         generate_test_data(num_validators, faults, num_transitions);
 
     // Prover generates the proof given the params
-    let proof = prover::prove(&params, num_validators as u32, &first_epoch, &transitions).unwrap();
+    let proof = prover::prove(
+        &params,
+        num_validators as u32,
+        &first_epoch,
+        &transitions,
+        generate_constraints,
+    )
+    .unwrap();
 
     // Verifier checks the proof
     let res = verifier::verify(params.vk().0, &first_epoch, &last_epoch, &proof);

--- a/crates/epoch-snark/tests/e2e.rs
+++ b/crates/epoch-snark/tests/e2e.rs
@@ -12,7 +12,7 @@ fn prover_verifier_groth16() {
     let faults = 1;
     let num_validators = 3 * faults + 1;
 
-    let generate_constraints = false;
+    let hashes_in_bls12_377 = true;
 
     // Trusted setup
     let params = setup::trusted_setup(
@@ -20,7 +20,7 @@ fn prover_verifier_groth16() {
         num_transitions,
         faults,
         rng,
-        generate_constraints,
+        hashes_in_bls12_377,
     )
     .unwrap();
 

--- a/crates/epoch-snark/tests/e2e.rs
+++ b/crates/epoch-snark/tests/e2e.rs
@@ -30,22 +30,15 @@ fn prover_verifier_groth16() {
         generate_test_data(num_validators, faults, num_transitions);
 
     // Prover generates the proof given the params
-    let proof = prover::prove(
-        &params,
-        num_validators as u32,
-        &first_epoch,
-        &transitions,
-        generate_constraints,
-    )
-    .unwrap();
+    let proof = prover::prove(&params, num_validators as u32, &first_epoch, &transitions).unwrap();
 
     // Verifier checks the proof
-    let res = verifier::verify(params.vk().0, &first_epoch, &last_epoch, &proof);
+    let res = verifier::verify(&params.epochs.vk, &first_epoch, &last_epoch, &proof);
     assert!(res.is_ok());
 
     // Serialize the proof / vk
     let mut serialized_vk = vec![];
-    params.vk().0.serialize(&mut serialized_vk).unwrap();
+    params.epochs.vk.serialize(&mut serialized_vk).unwrap();
     let mut serialized_proof = vec![];
     proof.serialize(&mut serialized_proof).unwrap();
     dbg!(hex::encode(&serialized_vk));


### PR DESCRIPTION
As discussed, we want to allow the system to run in the following 2 modes:
- 1 proof, 1 setup, but CRH->XOF in SW6
- 2 proofs (one inside another), 2 setups, but CRH->XOF in BLS12-377 (much faster)

This PR enables that to happen by changing the high-level API components to view the HashToBits proof as an optional "helper". If it is present, 2 proofs will be generated, otherwise only 1 is.

This is done on the basis that the prover overhead will justify the overhead from having to do 2 setups (1 per snark).

`cargo run --release --example proof 30 10 true` will generate 10 epoch proofs for 30 validators with hashproofs in BLS12-377 (2-proof method), toggling the last argument to `false` will do the hashproofs in SW6.