### PR TITLE
examples: calculate number of constraints from empty circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core",
 ]
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "algebra-core"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core-derive",
  "derivative",
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "algebra-core-derive"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -95,11 +95,6 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "bench-utils"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
-
-[[package]]
-name = "bench-utils"
-version = "0.1.0"
 source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
 dependencies = [
  "colored",
@@ -139,7 +134,7 @@ name = "bls-crypto"
 version = "0.1.0"
 dependencies = [
  "algebra",
- "bench-utils 0.1.0 (git+https://github.com/scipr-lab/zexe)",
+ "bench-utils",
  "blake2s_simd",
  "byteorder",
  "clap",
@@ -389,10 +384,10 @@ dependencies = [
 [[package]]
 name = "crypto-primitives"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core",
- "bench-utils 0.1.0 (git+https://github.com/gakonst/zexe?branch=constraint-counter)",
+ "bench-utils",
  "blake2",
  "derivative",
  "digest",
@@ -471,7 +466,7 @@ name = "epoch-snark"
 version = "0.1.0"
 dependencies = [
  "algebra",
- "bench-utils 0.1.0 (git+https://github.com/scipr-lab/zexe)",
+ "bench-utils",
  "blake2s_simd",
  "bls-crypto",
  "bls-gadgets",
@@ -492,7 +487,7 @@ dependencies = [
 [[package]]
 name = "ff-fft"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core",
  "rand",
@@ -528,10 +523,10 @@ dependencies = [
 [[package]]
 name = "gm17"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core",
- "bench-utils 0.1.0 (git+https://github.com/gakonst/zexe?branch=constraint-counter)",
+ "bench-utils",
  "ff-fft",
  "r1cs-core",
  "rand",
@@ -542,10 +537,10 @@ dependencies = [
 [[package]]
 name = "groth16"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core",
- "bench-utils 0.1.0 (git+https://github.com/gakonst/zexe?branch=constraint-counter)",
+ "bench-utils",
  "ff-fft",
  "r1cs-core",
  "rand",
@@ -741,7 +736,7 @@ dependencies = [
 [[package]]
 name = "r1cs-core"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra-core",
  "smallvec",
@@ -750,7 +745,7 @@ dependencies = [
 [[package]]
 name = "r1cs-std"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+source = "git+https://github.com/scipr-lab/zexe#5674630058833faca90b117f2a860c5380e2cff6"
 dependencies = [
  "algebra",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "algebra"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core",
 ]
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "algebra-core"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core-derive",
  "derivative",
@@ -41,11 +41,11 @@ dependencies = [
 [[package]]
 name = "algebra-core-derive"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -95,6 +95,11 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "bench-utils"
 version = "0.1.0"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
+
+[[package]]
+name = "bench-utils"
+version = "0.1.0"
 source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
 dependencies = [
  "colored",
@@ -108,13 +113,14 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b77e29dbd0115e43938be2d5128ecf81c0353e00acaa65339a1242586951d9"
+checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 dependencies = [
  "byte-tools",
  "crypto-mac",
  "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -133,7 +139,7 @@ name = "bls-crypto"
 version = "0.1.0"
 dependencies = [
  "algebra",
- "bench-utils",
+ "bench-utils 0.1.0 (git+https://github.com/scipr-lab/zexe)",
  "blake2s_simd",
  "byteorder",
  "clap",
@@ -179,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "byte-tools"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -372,21 +378,21 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "constant_time_eq",
  "generic-array",
+ "subtle",
 ]
 
 [[package]]
 name = "crypto-primitives"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core",
- "bench-utils",
+ "bench-utils 0.1.0 (git+https://github.com/gakonst/zexe?branch=constraint-counter)",
  "blake2",
  "derivative",
  "digest",
@@ -423,20 +429,20 @@ dependencies = [
 
 [[package]]
 name = "derivative"
-version = "1.0.3"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942ca430eef7a3806595a6737bc388bf51adb888d3fc0dd1b50f1c170167ee3a"
+checksum = "1b94d2eb97732ec84b4e25eaf37db890e317b80e921f168c82cb5282473f8151"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "digest"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
 ]
@@ -465,7 +471,7 @@ name = "epoch-snark"
 version = "0.1.0"
 dependencies = [
  "algebra",
- "bench-utils",
+ "bench-utils 0.1.0 (git+https://github.com/scipr-lab/zexe)",
  "blake2s_simd",
  "bls-crypto",
  "bls-gadgets",
@@ -486,7 +492,7 @@ dependencies = [
 [[package]]
 name = "ff-fft"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core",
  "rand",
@@ -501,9 +507,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "generic-array"
-version = "0.9.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "typenum",
 ]
@@ -522,10 +528,10 @@ dependencies = [
 [[package]]
 name = "gm17"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core",
- "bench-utils",
+ "bench-utils 0.1.0 (git+https://github.com/gakonst/zexe?branch=constraint-counter)",
  "ff-fft",
  "r1cs-core",
  "rand",
@@ -536,10 +542,10 @@ dependencies = [
 [[package]]
 name = "groth16"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core",
- "bench-utils",
+ "bench-utils 0.1.0 (git+https://github.com/gakonst/zexe?branch=constraint-counter)",
  "ff-fft",
  "r1cs-core",
  "rand",
@@ -686,6 +692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,18 +709,9 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -717,7 +720,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -728,26 +731,17 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "r1cs-core"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra-core",
  "smallvec",
@@ -756,7 +750,7 @@ dependencies = [
 [[package]]
 name = "r1cs-std"
 version = "0.1.0"
-source = "git+https://github.com/scipr-lab/zexe#8cb038c93e45286b411c9e5f0ad7a8151090cfd7"
+source = "git+https://github.com/gakonst/zexe?branch=constraint-counter#8258ecd46c28b89545b13da9bb2f91e0dbece16c"
 dependencies = [
  "algebra",
  "derivative",
@@ -977,9 +971,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1015,15 +1009,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "syn"
-version = "0.15.44"
+name = "subtle"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
@@ -1031,9 +1020,9 @@ version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1069,9 +1058,9 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.16",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1121,8 +1110,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.3",
- "syn 1.0.16",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1186,12 +1175,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,3 @@ opt-level = 3
 incremental = true
 debug-assertions = true
 debug = true
-
-[patch."https://github.com/scipr-lab/zexe"]
-algebra = { version = "0.1.0", package = "algebra", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" }
-ff-fft = { package = "ff-fft", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" }
-groth16 = { package = "groth16", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" }
-r1cs-core = { package = "r1cs-core", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 
-r1cs-std = { package = "r1cs-std", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 
-gm17 = { package = "gm17", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 
-crypto-primitives = { package = "crypto-primitives", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,12 @@ opt-level = 3
 incremental = true
 debug-assertions = true
 debug = true
+
+[patch."https://github.com/scipr-lab/zexe"]
+algebra = { version = "0.1.0", package = "algebra", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" }
+ff-fft = { package = "ff-fft", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" }
+groth16 = { package = "groth16", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" }
+r1cs-core = { package = "r1cs-core", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 
+r1cs-std = { package = "r1cs-std", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 
+gm17 = { package = "gm17", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 
+crypto-primitives = { package = "crypto-primitives", git = "https://github.com/gakonst/zexe", branch = "constraint-counter" } 

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -381,7 +381,7 @@ mod verify_one_message {
             0,
         );
         assert!(cs.is_satisfied());
-        assert_eq!(cs.num_constraints(), 20516);
+        assert_eq!(cs.num_constraints(), 21754);
 
         // random sig fails
         let cs = cs_verify::<Bls12_377, SW6Fr, Bls12_377PairingGadget>(

--- a/crates/bls-gadgets/src/smaller_than.rs
+++ b/crates/bls-gadgets/src/smaller_than.rs
@@ -21,7 +21,7 @@ impl<ConstraintF: PrimeField> SmallerThanGadget<ConstraintF> {
         let two = ConstraintF::one() + ConstraintF::one();
         let d0 = a.sub(cs.ns(|| "a - b"), b)?;
         let d = d0.mul_by_constant(cs.ns(|| "mul 2"), &two)?;
-        let d_bits = d.to_bits_strict(cs.ns(|| "d to bits"))?;
+        let d_bits = d.to_bits(cs.ns(|| "d to bits"))?;
         let d_bits_len = d_bits.len();
         Ok(d_bits[d_bits_len - 1])
     }

--- a/crates/bls-gadgets/src/smaller_than.rs
+++ b/crates/bls-gadgets/src/smaller_than.rs
@@ -21,7 +21,7 @@ impl<ConstraintF: PrimeField> SmallerThanGadget<ConstraintF> {
         let two = ConstraintF::one() + ConstraintF::one();
         let d0 = a.sub(cs.ns(|| "a - b"), b)?;
         let d = d0.mul_by_constant(cs.ns(|| "mul 2"), &two)?;
-        let d_bits = d.to_non_unique_bits(cs.ns(|| "d to bits"))?;
+        let d_bits = d.to_bits(cs.ns(|| "d to bits"))?;
         let d_bits_len = d_bits.len();
         Ok(d_bits[d_bits_len - 1])
     }

--- a/crates/bls-gadgets/src/smaller_than.rs
+++ b/crates/bls-gadgets/src/smaller_than.rs
@@ -21,7 +21,7 @@ impl<ConstraintF: PrimeField> SmallerThanGadget<ConstraintF> {
         let two = ConstraintF::one() + ConstraintF::one();
         let d0 = a.sub(cs.ns(|| "a - b"), b)?;
         let d = d0.mul_by_constant(cs.ns(|| "mul 2"), &two)?;
-        let d_bits = d.to_bits(cs.ns(|| "d to bits"))?;
+        let d_bits = d.to_non_unique_bits(cs.ns(|| "d to bits"))?;
         let d_bits_len = d_bits.len();
         Ok(d_bits[d_bits_len - 1])
     }

--- a/crates/epoch-snark/examples/constraints.rs
+++ b/crates/epoch-snark/examples/constraints.rs
@@ -1,6 +1,6 @@
 use epoch_snark::{api::BLSCurve, gadgets::ValidatorSetUpdate};
 use r1cs_core::ConstraintSynthesizer;
-use r1cs_std::test_constraint_counter::TestConstraintCounter;
+use r1cs_std::test_constraint_counter::ConstraintCounter;
 use std::env;
 
 fn main() {
@@ -18,16 +18,15 @@ fn main() {
         .expect("NaN");
     let faults = (num_validators - 1) / 3;
 
-    let mut cs = TestConstraintCounter::new();
+    let mut cs = ConstraintCounter::new();
     let circuit = ValidatorSetUpdate::<BLSCurve>::empty(num_validators, num_epochs, faults, None);
     circuit.generate_constraints(&mut cs).unwrap();
 
     println!(
-        "Number of constraints for {} epochs ({} validators, {} faults, hashes in BLS12-377 {}): {}",
+        "Number of constraints for {} epochs ({} validators, {} faults, hashes in SW6): {}",
         num_epochs,
         num_validators,
         faults,
-        false,
         cs.num_constraints()
     )
 }

--- a/crates/epoch-snark/examples/constraints.rs
+++ b/crates/epoch-snark/examples/constraints.rs
@@ -1,19 +1,9 @@
-use algebra::{bls12_377::G1Projective, Zero};
-use epoch_snark::{
-    api::{prover, BLSCurve, CPFrParams},
-    gadgets::{HashToBits, ValidatorSetUpdate},
-};
-use groth16::generate_random_parameters;
+use epoch_snark::{api::BLSCurve, gadgets::ValidatorSetUpdate};
 use r1cs_core::ConstraintSynthesizer;
-use r1cs_std::test_constraint_system::TestConstraintSystem;
+use r1cs_std::test_constraint_counter::TestConstraintCounter;
 use std::env;
 
-#[path = "../tests/fixtures.rs"]
-mod fixtures;
-use fixtures::generate_test_data;
-
 fn main() {
-    let rng = &mut rand::thread_rng();
     let mut args = env::args();
     args.next().unwrap(); // discard the program name
     let num_validators = args
@@ -26,50 +16,18 @@ fn main() {
         .expect("num epochs was expected")
         .parse()
         .expect("NaN");
-    let hashes_in_bls12_377: bool = args
-        .next()
-        .expect("expected flag for generating or not constraints inside BLS12_377")
-        .parse()
-        .expect("not a bool");
     let faults = (num_validators - 1) / 3;
 
-    // Make a random initialization of the circuit
-    let (first_epoch, transitions, _) = generate_test_data(num_validators, faults, num_epochs);
-
-    // Trusted setup for the HashToBits circuit if required
-    let hash_helper = if hashes_in_bls12_377 {
-        let empty_hash_to_bits = HashToBits::empty::<CPFrParams>(num_epochs);
-        let params = generate_random_parameters(empty_hash_to_bits, rng).unwrap();
-        let helper = prover::generate_hash_helper(&params, &transitions).unwrap();
-        Some(helper)
-    } else {
-        None
-    };
-
-    let asig = transitions.iter().fold(G1Projective::zero(), |acc, epoch| {
-        acc + epoch.aggregate_signature.get_sig()
-    });
-    let epochs = transitions
-        .iter()
-        .map(|transition| prover::to_update(transition))
-        .collect::<Vec<_>>();
-    let circuit = ValidatorSetUpdate::<BLSCurve> {
-        initial_epoch: prover::to_epoch_data(&first_epoch),
-        epochs,
-        aggregated_signature: Some(asig),
-        num_validators: num_validators as u32,
-        hash_helper,
-    };
-
-    // generate test constraints and log them
-    let mut cs = TestConstraintSystem::new();
+    let mut cs = TestConstraintCounter::new();
+    let circuit = ValidatorSetUpdate::<BLSCurve>::empty(num_validators, num_epochs, faults, None);
     circuit.generate_constraints(&mut cs).unwrap();
 
     println!(
-        "Number of constraints for {} epochs ({} validators, hashes in BLS12-377 {}): {}",
+        "Number of constraints for {} epochs ({} validators, {} faults, hashes in BLS12-377 {}): {}",
         num_epochs,
         num_validators,
-        hashes_in_bls12_377,
+        faults,
+        false,
         cs.num_constraints()
     )
 }


### PR DESCRIPTION
Depends on https://github.com/scipr-lab/zexe/pull/151

Zexe latest master requires us to us `to_bits` instead of `to_bits_strict`, which costs slightly more constraints.