### PR TITLE
Batched BLS Verification

### DIFF
--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -44,3 +44,6 @@ path = "examples/pop_csv.rs"
 
 [lib]
 crate-type = ["lib", "staticlib"]
+
+[features]
+test-helpers = []

--- a/crates/bls-crypto/src/lib.rs
+++ b/crates/bls-crypto/src/lib.rs
@@ -3,6 +3,9 @@ pub mod bls;
 pub mod curve;
 pub mod hash;
 
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers;
+
 // Clean public API
 pub use bls::keys::{PrivateKey, PublicKey, Signature};
 pub use curve::hash::try_and_increment::TryAndIncrement;

--- a/crates/bls-crypto/src/test_helpers.rs
+++ b/crates/bls-crypto/src/test_helpers.rs
@@ -1,0 +1,80 @@
+use algebra::{PairingEngine, ProjectiveCurve, UniformRand, Zero};
+
+// Same RNG for all tests
+pub fn rng() -> rand::rngs::ThreadRng {
+    rand::thread_rng()
+}
+
+/// generate a keypair
+pub fn keygen<E: PairingEngine>() -> (E::Fr, E::G2Projective) {
+    let rng = &mut rng();
+    let generator = E::G2Projective::prime_subgroup_generator();
+
+    let secret_key = E::Fr::rand(rng);
+    let pubkey = generator.mul(secret_key);
+    (secret_key, pubkey)
+}
+
+/// generate N keypairs
+pub fn keygen_mul<E: PairingEngine>(num: usize) -> (Vec<E::Fr>, Vec<E::G2Projective>) {
+    let mut secret_keys = Vec::new();
+    let mut public_keys = Vec::new();
+    for _ in 0..num {
+        let (secret_key, public_key) = keygen::<E>();
+        secret_keys.push(secret_key);
+        public_keys.push(public_key);
+    }
+    (secret_keys, public_keys)
+}
+
+/// generate N * sets of keypair vectors, each of size 3-7
+#[allow(clippy::type_complexity)]
+pub fn keygen_batch<E: PairingEngine>(
+    batch_size: usize,
+    num_per_batch: usize,
+) -> (Vec<Vec<E::Fr>>, Vec<Vec<E::G2Projective>>) {
+    let mut secret_keys = Vec::new();
+    let mut public_keys = Vec::new();
+    (0..batch_size).for_each(|_| {
+        let (secret_keys_i, public_keys_i) = keygen_mul::<E>(num_per_batch);
+        secret_keys.push(secret_keys_i);
+        public_keys.push(public_keys_i);
+    });
+    (secret_keys, public_keys)
+}
+
+/// sum the elements in the provided slice
+pub fn sum<P: ProjectiveCurve>(elements: &[P]) -> P {
+    elements.iter().fold(P::zero(), |acc, key| acc + key)
+}
+
+/// N messages get signed by N committees of varying sizes
+/// N aggregate signatures are returned
+pub fn sign_batch<E: PairingEngine>(
+    secret_keys: &[Vec<E::Fr>],
+    messages: &[E::G1Projective],
+) -> Vec<E::G1Projective> {
+    secret_keys
+        .iter()
+        .zip(messages)
+        .map(|(secret_keys, message)| {
+            let (_, asig) = sign::<E>(*message, &secret_keys);
+            asig
+        })
+        .collect::<Vec<_>>()
+}
+
+// signs a message with a vector of secret keys and returns the list of sigs + the agg sig
+pub fn sign<E: PairingEngine>(
+    message_hash: E::G1Projective,
+    secret_keys: &[E::Fr],
+) -> (Vec<E::G1Projective>, E::G1Projective) {
+    let sigs = secret_keys
+        .iter()
+        .map(|key| message_hash.mul(*key))
+        .collect::<Vec<_>>();
+    let asig = sigs
+        .iter()
+        .fold(E::G1Projective::zero(), |acc, sig| acc + sig);
+    (sigs, asig)
+}

--- a/crates/bls-gadgets/Cargo.toml
+++ b/crates/bls-gadgets/Cargo.toml
@@ -21,6 +21,7 @@ tracing = "0.1.13"
 rand_xorshift = { version = "0.2" }
 rand = { version = "0.7" }
 groth16 = { git = "https://github.com/scipr-lab/zexe" }
+bls-crypto = { path = "../bls-crypto", features = ["test-helpers"] }
 
 [features]
 test-helpers = ["rand", "rand_xorshift"]

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -265,7 +265,8 @@ where
 #[cfg(test)]
 mod verify_one_message {
     use super::*;
-    use crate::test_helpers::*;
+    use crate::test_helpers::alloc_vec;
+    use bls_crypto::test_helpers::*;
 
     use algebra::{
         bls12_377::{Bls12_377, Fr as Bls12_377Fr, G1Projective, G2Projective},

--- a/crates/bls-gadgets/src/lib.rs
+++ b/crates/bls-gadgets/src/lib.rs
@@ -78,73 +78,9 @@ pub fn bytes_to_bits(bytes: &[u8], bits_to_take: usize) -> Vec<bool> {
 
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {
-    use algebra::{Field, Group, PairingEngine, ProjectiveCurve, UniformRand, Zero};
+    use algebra::{Field, Group};
     use r1cs_core::ConstraintSystem;
     use r1cs_std::groups::GroupGadget;
-
-    // Same RNG for all tests
-    pub fn rng() -> rand::rngs::ThreadRng {
-        rand::thread_rng()
-    }
-
-    /// generate a keypair
-    pub fn keygen<E: PairingEngine>() -> (E::Fr, E::G2Projective) {
-        let rng = &mut rng();
-        let generator = E::G2Projective::prime_subgroup_generator();
-
-        let secret_key = E::Fr::rand(rng);
-        let pubkey = generator.mul(secret_key);
-        (secret_key, pubkey)
-    }
-
-    /// generate N keypairs
-    pub fn keygen_mul<E: PairingEngine>(num: usize) -> (Vec<E::Fr>, Vec<E::G2Projective>) {
-        let mut secret_keys = Vec::new();
-        let mut public_keys = Vec::new();
-        for _ in 0..num {
-            let (secret_key, public_key) = keygen::<E>();
-            secret_keys.push(secret_key);
-            public_keys.push(public_key);
-        }
-        (secret_keys, public_keys)
-    }
-
-    /// generate N * sets of keypair vectors, each of size 3-7
-    #[allow(clippy::type_complexity)]
-    pub fn keygen_batch<E: PairingEngine>(
-        batch_size: usize,
-        num_per_batch: usize,
-    ) -> (Vec<Vec<E::Fr>>, Vec<Vec<E::G2Projective>>) {
-        let mut secret_keys = Vec::new();
-        let mut public_keys = Vec::new();
-        (0..batch_size).for_each(|_| {
-            let (secret_keys_i, public_keys_i) = keygen_mul::<E>(num_per_batch);
-            secret_keys.push(secret_keys_i);
-            public_keys.push(public_keys_i);
-        });
-        (secret_keys, public_keys)
-    }
-
-    /// sum the elements in the provided slice
-    pub fn sum<P: ProjectiveCurve>(elements: &[P]) -> P {
-        elements.iter().fold(P::zero(), |acc, key| acc + key)
-    }
-
-    /// N messages get signed by N committees of varying sizes
-    /// N aggregate signatures are returned
-    pub fn sign_batch<E: PairingEngine>(
-        secret_keys: &[Vec<E::Fr>],
-        messages: &[E::G1Projective],
-    ) -> Vec<E::G1Projective> {
-        secret_keys
-            .iter()
-            .zip(messages)
-            .map(|(secret_keys, message)| {
-                let (_, asig) = sign::<E>(*message, &secret_keys);
-                asig
-            })
-            .collect::<Vec<_>>()
-    }
 
     /// Allocates an array of group elements to a group gadget
     pub fn alloc_vec<F: Field, G: Group, GG: GroupGadget<G, F>, CS: ConstraintSystem<F>>(
@@ -156,20 +92,5 @@ pub mod test_helpers {
             .enumerate()
             .map(|(i, element)| GG::alloc(&mut cs.ns(|| format!("{}", i)), || Ok(element)).unwrap())
             .collect::<Vec<_>>()
-    }
-
-    // signs a message with a vector of secret keys and returns the list of sigs + the agg sig
-    pub fn sign<E: PairingEngine>(
-        message_hash: E::G1Projective,
-        secret_keys: &[E::Fr],
-    ) -> (Vec<E::G1Projective>, E::G1Projective) {
-        let sigs = secret_keys
-            .iter()
-            .map(|key| message_hash.mul(*key))
-            .collect::<Vec<_>>();
-        let asig = sigs
-            .iter()
-            .fold(E::G1Projective::zero(), |acc, sig| acc + sig);
-        (sigs, asig)
     }
 }

--- a/crates/epoch-snark/Cargo.toml
+++ b/crates/epoch-snark/Cargo.toml
@@ -27,6 +27,7 @@ rand_xorshift = { version = "0.2" }
 bench-utils = { git = "https://github.com/scipr-lab/zexe", features = ["print-trace"] }
 hex = "0.3.2"
 bls-gadgets = { path = "../bls-gadgets", features = ["test-helpers"] }
+bls-crypto = { path = "../bls-crypto", features = ["test-helpers"] }
 
 [lib]
 crate-type = ["lib", "staticlib"]

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -241,7 +241,7 @@ mod tests {
 
     use crate::gadgets::single_update::test_helpers::generate_single_update;
     use algebra::bls12_377::G1Projective;
-    use bls_gadgets::test_helpers::{keygen_batch, keygen_mul, sign_batch, sum};
+    use bls_crypto::test_helpers::{keygen_batch, keygen_mul, sign_batch, sum};
     use r1cs_std::test_constraint_system::TestConstraintSystem;
 
     type Curve = Bls12_377;

--- a/crates/epoch-snark/tests/fixtures.rs
+++ b/crates/epoch-snark/tests/fixtures.rs
@@ -3,8 +3,8 @@ use algebra::{
     ProjectiveCurve, Zero,
 };
 
+use bls_crypto::test_helpers::{keygen_batch, keygen_mul};
 use bls_crypto::{PublicKey, Signature};
-use bls_gadgets::test_helpers::{keygen_batch, keygen_mul};
 use epoch_snark::epoch_block::{EpochBlock, EpochTransition};
 
 // Returns the initial epoch and a list of signed `num_epochs` state transitions


### PR DESCRIPTION
As title. n+1 pairings instead of 2n for n messages. We had that already implemented for the SNARK code.

Also refactored some test helpers for convenience.