### PR TITLE
Batch BLS Verification - Go Bindings

### DIFF
--- a/crates/bls-crypto/src/lib.rs
+++ b/crates/bls-crypto/src/lib.rs
@@ -50,7 +50,7 @@ fn convert_result_to_bool<T, E: Display, F: Fn() -> Result<T, E>>(f: F) -> bool 
 }
 
 #[no_mangle]
-/// Initializes the lazily evaluated hashers. Should
+/// Initializes the lazily evaluated hashers.
 pub extern "C" fn init() {
     &*COMPOSITE_HASH_TO_G1;
     &*DIRECT_HASH_TO_G1;

--- a/go/bls/bls.go
+++ b/go/bls/bls.go
@@ -259,6 +259,7 @@ func BatchVerifyEpochs(messages []*Message, shouldUseCompositeHasher bool) error
 	// Allocate a contiguous slice of memory for our Messages
 	size := int(unsafe.Sizeof(C.MessageFFI{}))
 	list := C.malloc(C.size_t(size * msg_len))
+	defer C.free(list)
 	for i := 0; i < msg_len; i++ {
 		// Get a reference to the memory where the i_th element will be at
 		ptr := unsafe.Pointer(uintptr(list) + uintptr(size*i))

--- a/go/bls/bls.h
+++ b/go/bls/bls.h
@@ -130,7 +130,7 @@ bool hash_direct(const uint8_t *in_message,
                  bool use_pop);
 
 /**
- * Initializes the lazily evaluated hashers. Should
+ * Initializes the lazily evaluated hashers.
  */
 void init(void);
 

--- a/go/bls/bls.h
+++ b/go/bls/bls.h
@@ -1,38 +1,171 @@
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 
-struct PrivateKey;
 typedef struct PrivateKey PrivateKey;
 
-struct PublicKey;
 typedef struct PublicKey PublicKey;
 
-struct Signature;
 typedef struct Signature Signature;
 
-void init();
-bool generate_private_key(PrivateKey**);
-bool deserialize_private_key(const unsigned char*, int32_t, PrivateKey**);
-bool serialize_private_key(const PrivateKey*, unsigned char**, int32_t*);
-bool private_key_to_public_key(const PrivateKey*, PublicKey**);
-bool sign_message(const PrivateKey*, const unsigned char*, int32_t, const unsigned char*, int32_t, bool, Signature**);
-bool sign_pop(const PrivateKey*, const unsigned char*, int32_t, Signature**);
-void destroy_private_key(PrivateKey*);
-void free_vec(unsigned char*, int32_t);
-bool deserialize_public_key(const unsigned char*, int32_t, PublicKey**);
-bool serialize_public_key(const PublicKey*, unsigned char**, int32_t*);
-void destroy_public_key(PublicKey*);
-bool deserialize_signature(const unsigned char*, int32_t, Signature**);
-bool serialize_signature(const Signature*, unsigned char**, int32_t*);
-void destroy_signature(Signature*);
-bool verify_signature(const PublicKey*, const unsigned char*, int32_t, const unsigned char*, int32_t, const Signature*, bool, bool*);
-bool verify_pop(const PublicKey*, const unsigned char*, int32_t, const Signature*, bool*);
-bool aggregate_public_keys(const PublicKey**, int32_t, PublicKey**);
-bool aggregate_public_keys_subtract(const PublicKey*, const PublicKey**, int32_t, PublicKey**);
-bool aggregate_signatures(const Signature**, int32_t, Signature**);
+/**
+ * Data structure which is used to store buffers of varying length
+ */
+typedef struct {
+  /**
+   * Pointer to the message
+   */
+  const uint8_t *ptr;
+  /**
+   * The length of the buffer
+   */
+  uintptr_t len;
+} Buffer;
 
-bool encode_epoch_block_to_bytes(uint16_t, uint32_t, const PublicKey**, int32_t, bool, unsigned char**, int32_t*);
-bool hash_direct(const unsigned char*, int32_t, unsigned char**, int32_t*, bool);
-bool hash_composite(const unsigned char*, int32_t, const unsigned char*, int32_t, unsigned char**, int32_t*); 
-bool compress_signature(const unsigned char*, int32_t, unsigned char**, int32_t*);
-bool compress_pubkey(const unsigned char*, int32_t, unsigned char**, int32_t*);
+/**
+ * Pointers to the necessary data for signature verification of an epoch
+ */
+typedef struct {
+  /**
+   * Pointer to the data which was signed
+   */
+  Buffer data;
+  /**
+   * Pointer to the extra data which was signed alongside the `data`
+   */
+  Buffer extra;
+  /**
+   * Pointer to the aggregate public key of the epoch which signed the data/extra pair
+   */
+  const PublicKey *public_key;
+  /**
+   * Pointer to the aggregate signature corresponding the aggregate public key
+   */
+  const Signature *sig;
+} MessageFFI;
+
+bool aggregate_public_keys(const PublicKey *const *in_public_keys,
+                           int in_public_keys_len,
+                           PublicKey **out_public_key);
+
+bool aggregate_public_keys_subtract(const PublicKey *in_aggregated_public_key,
+                                    const PublicKey *const *in_public_keys,
+                                    int in_public_keys_len,
+                                    PublicKey **out_public_key);
+
+bool aggregate_signatures(const Signature *const *in_signatures,
+                          int in_signatures_len,
+                          Signature **out_signature);
+
+/**
+ * Receives a list of messages composed of:
+ * 1. the data
+ * 1. the public keys which signed on the data
+ * 1. the signature produced by the public keys
+ *
+ * It will create the aggregate signature from all messages and execute batch
+ * verification against each (data, publickey) pair. Internally calls `Signature::batch_verify`
+ *
+ * The verification equation can be found in pg.11 from
+ * https://eprint.iacr.org/2018/483.pdf: "Batch verification"
+ */
+bool batch_verify_signature(const MessageFFI *messages_ptr,
+                            uintptr_t messages_len,
+                            bool should_use_composite,
+                            bool *verified);
+
+bool compress_pubkey(const uint8_t *in_pubkey,
+                     int in_pubkey_len,
+                     uint8_t **out_pubkey,
+                     int *out_len);
+
+bool compress_signature(const uint8_t *in_signature,
+                        int in_signature_len,
+                        uint8_t **out_signature,
+                        int *out_len);
+
+bool deserialize_private_key(const uint8_t *in_private_key_bytes,
+                             int in_private_key_bytes_len,
+                             PrivateKey **out_private_key);
+
+bool deserialize_public_key(const uint8_t *in_public_key_bytes,
+                            int in_public_key_bytes_len,
+                            PublicKey **out_public_key);
+
+bool deserialize_signature(const uint8_t *in_signature_bytes,
+                           int in_signature_bytes_len,
+                           Signature **out_signature);
+
+void destroy_private_key(PrivateKey *private_key);
+
+void destroy_public_key(PublicKey *public_key);
+
+void destroy_signature(Signature *signature);
+
+bool encode_epoch_block_to_bytes(unsigned short in_epoch_index,
+                                 unsigned int in_maximum_non_signers,
+                                 const PublicKey *const *in_added_public_keys,
+                                 int in_added_public_keys_len,
+                                 bool in_should_encode_aggregated_pk,
+                                 uint8_t **out_bytes,
+                                 int *out_len);
+
+
+void free_vec(uint8_t *bytes, int len);
+
+bool generate_private_key(PrivateKey **out_private_key);
+
+bool hash_composite(const uint8_t *in_message,
+                    int in_message_len,
+                    const uint8_t *in_extra_data,
+                    int in_extra_data_len,
+                    uint8_t **out_hash,
+                    int *out_len);
+
+bool hash_direct(const uint8_t *in_message,
+                 int in_message_len,
+                 uint8_t **out_hash,
+                 int *out_len,
+                 bool use_pop);
+
+/**
+ * Initializes the lazily evaluated hashers. Should
+ */
+void init(void);
+
+bool private_key_to_public_key(const PrivateKey *in_private_key, PublicKey **out_public_key);
+
+bool serialize_private_key(const PrivateKey *in_private_key, uint8_t **out_bytes, int *out_len);
+
+bool serialize_public_key(const PublicKey *in_public_key, uint8_t **out_bytes, int *out_len);
+
+bool serialize_signature(const Signature *in_signature, uint8_t **out_bytes, int *out_len);
+
+bool sign_message(const PrivateKey *in_private_key,
+                  const uint8_t *in_message,
+                  int in_message_len,
+                  const uint8_t *in_extra_data,
+                  int in_extra_data_len,
+                  bool should_use_composite,
+                  Signature **out_signature);
+
+bool sign_pop(const PrivateKey *in_private_key,
+              const uint8_t *in_message,
+              int in_message_len,
+              Signature **out_signature);
+
+bool verify_pop(const PublicKey *in_public_key,
+                const uint8_t *in_message,
+                int in_message_len,
+                const Signature *in_signature,
+                bool *out_verified);
+
+bool verify_signature(const PublicKey *in_public_key,
+                      const uint8_t *in_message,
+                      int in_message_len,
+                      const uint8_t *in_extra_data,
+                      int in_extra_data_len,
+                      const Signature *in_signature,
+                      bool should_use_composite,
+                      bool *out_verified);

--- a/go/bls/bls_test.go
+++ b/go/bls/bls_test.go
@@ -2,8 +2,54 @@ package bls
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 )
+
+// this test is a copy of the `bls-crypto::keys::test_batch_verify` Rust test
+func TestBatchVerify(t *testing.T) {
+	InitBLSCrypto()
+
+	num_epochs := 10
+	num_validators := 7
+
+	var msgs []*Message
+	for i := 0; i < num_epochs; i++ {
+		message := []byte(fmt.Sprintf("msg_%d", i))
+		extraData := []byte(fmt.Sprintf("extra_%d", i))
+		var epoch_sigs []*Signature
+		var epoch_pubkeys []*PublicKey
+		for j := 0; j < num_validators; j++ {
+			// generate a private key
+			privateKey, _ := GeneratePrivateKey()
+
+			// sign each message
+			signature, _ := privateKey.SignMessage(message, extraData, true)
+			// save the sig to generate the epoch's asig
+			epoch_sigs = append(epoch_sigs, signature)
+
+			// save the pubkey to generate the epoch's apubkey
+			publicKey, _ := privateKey.ToPublic()
+			epoch_pubkeys = append(epoch_pubkeys, publicKey)
+		}
+
+		epoch_asig, _ := AggregateSignatures(epoch_sigs)
+		epoch_apubkey, _ := AggregatePublicKeys(epoch_pubkeys)
+
+		msg := &Message{
+			Data:   message,
+			Extra:  extraData,
+			Pubkey: epoch_apubkey,
+			Sig:    epoch_asig,
+		}
+		msgs = append(msgs, msg)
+	}
+
+	err := BatchVerifyEpochs(msgs, true)
+	if err != nil {
+		t.Fatalf("batch verification failed, err: %s", err)
+	}
+}
 
 func TestAggregatedSig(t *testing.T) {
 	InitBLSCrypto()

--- a/go/bls/bls_test.go
+++ b/go/bls/bls_test.go
@@ -10,10 +10,14 @@ import (
 func TestBatchVerify(t *testing.T) {
 	InitBLSCrypto()
 
+	testBatchVerify(t, true)
+	testBatchVerify(t, false)
+}
+
+func testBatchVerify(t *testing.T, mode bool) {
 	num_epochs := 10
 	num_validators := 7
-
-	var msgs []*Message
+	var msgs []*SignedBlockHeader
 	for i := 0; i < num_epochs; i++ {
 		message := []byte(fmt.Sprintf("msg_%d", i))
 		extraData := []byte(fmt.Sprintf("extra_%d", i))
@@ -24,7 +28,7 @@ func TestBatchVerify(t *testing.T) {
 			privateKey, _ := GeneratePrivateKey()
 
 			// sign each message
-			signature, _ := privateKey.SignMessage(message, extraData, true)
+			signature, _ := privateKey.SignMessage(message, extraData, mode)
 			// save the sig to generate the epoch's asig
 			epoch_sigs = append(epoch_sigs, signature)
 
@@ -36,7 +40,7 @@ func TestBatchVerify(t *testing.T) {
 		epoch_asig, _ := AggregateSignatures(epoch_sigs)
 		epoch_apubkey, _ := AggregatePublicKeys(epoch_pubkeys)
 
-		msg := &Message{
+		msg := &SignedBlockHeader{
 			Data:   message,
 			Extra:  extraData,
 			Pubkey: epoch_apubkey,
@@ -45,7 +49,7 @@ func TestBatchVerify(t *testing.T) {
 		msgs = append(msgs, msg)
 	}
 
-	err := BatchVerifyEpochs(msgs, true)
+	err := BatchVerifyEpochs(msgs, mode)
 	if err != nil {
 		t.Fatalf("batch verification failed, err: %s", err)
 	}


### PR DESCRIPTION
As title.

- re-generated `bls.h` from cbindgen, better than having hand-written headers.
- Added a new `Message` type which should contain all the data per epoch (seal, extradata, aggregate pubkey and aggregate signature)
- Added a `BatchVerifyEpochs` that takes an array of `Message` along with which hashing mode it should use, transforms the data to the correct format and calls the underlying rust function.

NOTE: Using cgo with pointers is tricky! You need  to allocate the memory _in c_ (with a C.malloc) call, and then write directly to the pointer as done [here](https://github.com/celo-org/bls-zexe/pull/130/files#diff-8e469dd8fbfdccde93b553dbecb08742R260-R276)