### PR TITLE
fix(bls): cast lengths to int so that the functions can compile on android

### DIFF
--- a/go/bls/bls.go
+++ b/go/bls/bls.go
@@ -247,7 +247,7 @@ func toBuffer(data []byte) C.Buffer {
 	dataPtr, dataLen := sliceToPtr(data)
 	return C.Buffer{
 		ptr: dataPtr,
-		len: C.ulong(dataLen),
+		len: C.int(dataLen),
 	}
 }
 
@@ -282,7 +282,7 @@ func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHas
 	// make the batch verification call
 	success := C.batch_verify_signature(
 		(*C.MessageFFI)(messages_ptr),
-		C.ulong(msg_len),
+		C.int(msg_len),
 		C.bool(shouldUseCompositeHasher),
 		&verified,
 	)

--- a/go/bls/bls.h
+++ b/go/bls/bls.h
@@ -20,7 +20,7 @@ typedef struct {
   /**
    * The length of the buffer
    */
-  uintptr_t len;
+  int len;
 } Buffer;
 
 /**
@@ -71,7 +71,7 @@ bool aggregate_signatures(const Signature *const *in_signatures,
  * https://eprint.iacr.org/2018/483.pdf: "Batch verification"
  */
 bool batch_verify_signature(const MessageFFI *messages_ptr,
-                            uintptr_t messages_len,
+                            int messages_len,
                             bool should_use_composite,
                             bool *verified);
 


### PR DESCRIPTION
As title. Android does not have `ulong` datatypes. https://circleci.com/gh/celo-org/celo-blockchain/31359

Will unblock https://github.com/celo-org/celo-blockchain/pull/969