### PR TITLE
Key & Signature Serialization

### DIFF
--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kobi Gurkan <kobigurk@gmail.com>", "Michael Straka <mstraka@celo.org
 edition = "2018"
 
 [dependencies]
-algebra = { git = "https://github.com/scipr-lab/zexe", features = ["bls12_377", "edwards_sw6", "parallel"] }
+algebra = { git = "https://github.com/scipr-lab/zexe", features = ["derive", "bls12_377", "edwards_sw6", "parallel"] }
 crypto-primitives = { git = "https://github.com/scipr-lab/zexe", features = ["parallel"] }
 bench-utils = { git = "https://github.com/scipr-lab/zexe" }
 

--- a/crates/bls-crypto/examples/simple_signature.rs
+++ b/crates/bls-crypto/examples/simple_signature.rs
@@ -30,26 +30,26 @@ fn main() {
     let try_and_increment = TryAndIncrement::new(&composite_hasher);
     println!("try_and_increment");
     let sk1 = PrivateKey::generate(rng);
-    println!("sk1: {}", hex::encode(to_bytes!(sk1.get_sk()).unwrap()));
+    println!("sk1: {}", hex::encode(to_bytes!(sk1.as_ref()).unwrap()));
     let sk2 = PrivateKey::generate(rng);
-    println!("sk2: {}", hex::encode(to_bytes!(sk2.get_sk()).unwrap()));
+    println!("sk2: {}", hex::encode(to_bytes!(sk2.as_ref()).unwrap()));
     let sk3 = PrivateKey::generate(rng);
-    println!("sk3: {}", hex::encode(to_bytes!(sk3.get_sk()).unwrap()));
+    println!("sk3: {}", hex::encode(to_bytes!(sk3.as_ref()).unwrap()));
 
     println!("Starting!\n\n");
 
     let sig1 = sk1
         .sign(&message.as_bytes(), &[], &try_and_increment)
         .unwrap();
-    println!("sig1: {}", hex::encode(to_bytes!(sig1.get_sig()).unwrap()));
+    println!("sig1: {}", hex::encode(to_bytes!(sig1.as_ref()).unwrap()));
     let sig2 = sk2
         .sign(&message.as_bytes(), &[], &try_and_increment)
         .unwrap();
-    println!("sig2: {}", hex::encode(to_bytes!(sig2.get_sig()).unwrap()));
+    println!("sig2: {}", hex::encode(to_bytes!(sig2.as_ref()).unwrap()));
     let sig3 = sk3
         .sign(&message.as_bytes(), &[], &try_and_increment)
         .unwrap();
-    println!("sig3: {}", hex::encode(to_bytes!(sig3.get_sig()).unwrap()));
+    println!("sig3: {}", hex::encode(to_bytes!(sig3.as_ref()).unwrap()));
 
     let apk = PublicKey::aggregate(&[
         sk1.to_public(),
@@ -57,11 +57,11 @@ fn main() {
         sk3.to_public(),
         sk3.to_public(),
     ]);
-    println!("apk: {}", hex::encode(to_bytes!(apk.get_pk()).unwrap()));
+    println!("apk: {}", hex::encode(to_bytes!(apk.as_ref()).unwrap()));
     let asig1 = Signature::aggregate(&[sig1, sig3.clone()]);
     let asig2 = Signature::aggregate(&[sig2, sig3]);
     let asig = Signature::aggregate(&[asig1, asig2]);
-    println!("asig: {}", hex::encode(to_bytes!(asig.get_sig()).unwrap()));
+    println!("asig: {}", hex::encode(to_bytes!(asig.as_ref()).unwrap()));
     apk.verify(&message.as_bytes(), &[], &asig, &try_and_increment)
         .unwrap();
     println!("aggregated signature verified successfully");

--- a/crates/bls-crypto/src/bls/cache.rs
+++ b/crates/bls-crypto/src/bls/cache.rs
@@ -77,6 +77,6 @@ impl PublicKeyCache {
 
         cache.keys = keys;
         cache.combined = combined;
-        PublicKey::from_pk(combined)
+        PublicKey::from(combined)
     }
 }

--- a/crates/bls-crypto/src/bls/ffi.rs
+++ b/crates/bls-crypto/src/bls/ffi.rs
@@ -101,10 +101,10 @@ mod tests {
     fn msg_convert_ok() {
         let rng = &mut rand::thread_rng();
         let public_key = G2Projective::rand(rng);
-        let public_key = PublicKey::from_pk(public_key);
+        let public_key = PublicKey::from(public_key);
 
         let sig = G1Projective::rand(rng);
-        let sig = Signature::from_sig(sig);
+        let sig = Signature::from(sig);
         let msg = Message {
             data: &[1, 2, 3, 4],
             extra: &[5, 6, 7, 8],

--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -20,38 +20,38 @@ use std::{
     ops::Neg,
 };
 
-use super::{cache::PublicKeyCache, BLSError, Signature, POP_DOMAIN, SIG_DOMAIN};
+use super::{cache::PublicKeyCache, BLSError, PrivateKey, Signature, POP_DOMAIN, SIG_DOMAIN};
 
+/// A BLS public key on G2
 #[derive(Clone, Eq, Debug)]
-pub struct PublicKey {
-    pk: G2Projective,
+pub struct PublicKey(G2Projective);
+
+impl From<G2Projective> for PublicKey {
+    fn from(pk: G2Projective) -> PublicKey {
+        PublicKey(pk)
+    }
+}
+
+impl From<&PrivateKey> for PublicKey {
+    fn from(pk: &PrivateKey) -> PublicKey {
+        PublicKey::from(G2Projective::prime_subgroup_generator().mul(*pk.as_ref()))
+    }
 }
 
 impl AsRef<G2Projective> for PublicKey {
     fn as_ref(&self) -> &G2Projective {
-        &self.pk
+        &self.0
     }
 }
 
 impl PublicKey {
-    pub fn from_pk(pk: G2Projective) -> PublicKey {
-        PublicKey { pk }
-    }
-
-    pub fn get_pk(&self) -> G2Projective {
-        self.pk.clone()
-    }
-
-    pub fn clone(&self) -> PublicKey {
-        PublicKey::from_pk(self.pk)
-    }
-
     pub fn aggregate(public_keys: &[PublicKey]) -> PublicKey {
         let mut apk = G2Projective::zero();
-        for i in public_keys.iter() {
-            apk = apk + &(*i).pk;
+        for pk in public_keys.iter() {
+            apk = apk + pk.as_ref();
         }
-        PublicKey { pk: apk }
+
+        apk.into()
     }
 
     pub fn from_vec(data: &Vec<u8>) -> IoResult<PublicKey> {
@@ -86,7 +86,7 @@ impl PublicKey {
 
         let chosen_y = if y_over_half { bigger } else { smaller };
         let pk = G2Affine::new(x, chosen_y, false);
-        Ok(PublicKey::from_pk(pk.into_projective()))
+        Ok(PublicKey::from(pk.into_projective()))
     }
 
     pub fn verify<H: HashToG1>(
@@ -118,7 +118,7 @@ impl PublicKey {
     ) -> Result<(), Box<dyn Error>> {
         let pairing = Bls12_377::product_of_pairings(&vec![
             (
-                signature.get_sig().into_affine().into(),
+                signature.as_ref().into_affine().into(),
                 G2Affine::prime_subgroup_generator().neg().into(),
             ),
             (
@@ -126,7 +126,7 @@ impl PublicKey {
                     .hash::<Bls12_377Parameters>(domain, message, extra_data)?
                     .into_affine()
                     .into(),
-                self.pk.into_affine().into(),
+                self.0.into_affine().into(),
             ),
         ]);
         if pairing == Fq12::one() {
@@ -143,14 +143,16 @@ impl PartialEq for PublicKey {
         // equality operator in G2Projective.  We require byte-level equality here
         // for HashSet to work correctly.  HashSet requires that item equality
         // implies hash equality.
-        self.pk.x == other.pk.x && self.pk.y == other.pk.y && self.pk.z == other.pk.z
+        let a = self.as_ref();
+        let b = other.as_ref();
+        a.x == b.x && a.y == b.y && a.z == b.z
     }
 }
 
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Only hash based on `y` for slight speed improvement
-        self.pk.y.hash(state);
+        self.0.y.hash(state);
         // self.pk.x.hash(state);
         // self.pk.z.hash(state);
     }
@@ -159,7 +161,7 @@ impl Hash for PublicKey {
 impl ToBytes for PublicKey {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        let affine = self.pk.into_affine();
+        let affine = self.0.into_affine();
         let mut x_bytes: Vec<u8> = vec![];
         let y_c0_big = affine.y.c0.into_repr();
         let y_c1_big = affine.y.c1.into_repr();
@@ -188,27 +190,27 @@ impl FromBytes for PublicKey {
 
 impl CanonicalSerialize for PublicKey {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        self.pk.into_affine().serialize(writer)
+        self.0.into_affine().serialize(writer)
     }
 
     fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        self.pk.into_affine().serialize_uncompressed(writer)
+        self.0.into_affine().serialize_uncompressed(writer)
     }
 
     fn serialized_size(&self) -> usize {
-        self.pk.into_affine().serialized_size()
+        self.0.into_affine().serialized_size()
     }
 }
 
 impl CanonicalDeserialize for PublicKey {
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        Ok(PublicKey::from_pk(
+        Ok(PublicKey::from(
             G2Affine::deserialize(reader)?.into_projective(),
         ))
     }
 
     fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        Ok(PublicKey::from_pk(
+        Ok(PublicKey::from(
             G2Affine::deserialize_uncompressed(reader)?.into_projective(),
         ))
     }
@@ -231,8 +233,8 @@ mod test {
             let mut pk_bytes = vec![];
             pk.write(&mut pk_bytes).unwrap();
             let pk2 = PublicKey::read(pk_bytes.as_slice()).unwrap();
-            assert_eq!(pk.get_pk().into_affine().x, pk2.get_pk().into_affine().x);
-            assert_eq!(pk.get_pk().into_affine().y, pk2.get_pk().into_affine().y);
+            assert_eq!(pk.as_ref().into_affine().x, pk2.as_ref().into_affine().x);
+            assert_eq!(pk.as_ref().into_affine().y, pk2.as_ref().into_affine().y);
             assert_eq!(pk2.eq(&PublicKey::read(pk_bytes.as_slice()).unwrap()), true);
         }
     }

--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -9,7 +9,8 @@ use algebra::{
     },
     bytes::{FromBytes, ToBytes},
     curves::SWModelParameters,
-    AffineCurve, Field, One, PairingEngine, PrimeField, ProjectiveCurve, SquareRootField, Zero,
+    AffineCurve, CanonicalDeserialize, CanonicalSerialize, Field, One, PairingEngine, PrimeField,
+    ProjectiveCurve, SerializationError, SquareRootField, Zero,
 };
 
 use std::error::Error;
@@ -182,6 +183,34 @@ impl FromBytes for PublicKey {
         let mut x_bytes_with_y: Vec<u8> = vec![];
         reader.read_to_end(&mut x_bytes_with_y)?;
         PublicKeyCache::from_vec(&x_bytes_with_y)
+    }
+}
+
+impl CanonicalSerialize for PublicKey {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+        self.pk.into_affine().serialize(writer)
+    }
+
+    fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+        self.pk.into_affine().serialize_uncompressed(writer)
+    }
+
+    fn serialized_size(&self) -> usize {
+        self.pk.into_affine().serialized_size()
+    }
+}
+
+impl CanonicalDeserialize for PublicKey {
+    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+        Ok(PublicKey::from_pk(
+            G2Affine::deserialize(reader)?.into_projective(),
+        ))
+    }
+
+    fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+        Ok(PublicKey::from_pk(
+            G2Affine::deserialize_uncompressed(reader)?.into_projective(),
+        ))
     }
 }
 

--- a/crates/bls-crypto/src/bls/secret.rs
+++ b/crates/bls-crypto/src/bls/secret.rs
@@ -3,7 +3,7 @@ use crate::curve::hash::HashToG1;
 use algebra::{
     bls12_377::{Fr, G2Projective, Parameters as Bls12_377Parameters},
     bytes::{FromBytes, ToBytes},
-    ProjectiveCurve, UniformRand,
+    CanonicalDeserialize, CanonicalSerialize, ProjectiveCurve, SerializationError, UniformRand,
 };
 use rand::Rng;
 
@@ -13,7 +13,7 @@ use std::io::{Read, Result as IoResult, Write};
 
 use super::{PublicKey, Signature, POP_DOMAIN, SIG_DOMAIN};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct PrivateKey {
     sk: Fr,
 }

--- a/crates/bls-crypto/src/bls/secret.rs
+++ b/crates/bls-crypto/src/bls/secret.rs
@@ -1,9 +1,9 @@
 use crate::curve::hash::HashToG1;
 
 use algebra::{
-    bls12_377::{Fr, G2Projective, Parameters as Bls12_377Parameters},
+    bls12_377::{Fr, G1Projective, Parameters as Bls12_377Parameters},
     bytes::{FromBytes, ToBytes},
-    CanonicalDeserialize, CanonicalSerialize, ProjectiveCurve, SerializationError, UniformRand,
+    CanonicalDeserialize, CanonicalSerialize, Group, SerializationError, UniformRand,
 };
 use rand::Rng;
 
@@ -13,24 +13,30 @@ use std::io::{Read, Result as IoResult, Write};
 
 use super::{PublicKey, Signature, POP_DOMAIN, SIG_DOMAIN};
 
+/// A Private Key using a pairing friendly curve's Fr point
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct PrivateKey {
-    sk: Fr,
+pub struct PrivateKey(Fr);
+
+impl From<Fr> for PrivateKey {
+    fn from(sk: Fr) -> PrivateKey {
+        PrivateKey(sk)
+    }
+}
+
+impl AsRef<Fr> for PrivateKey {
+    fn as_ref(&self) -> &Fr {
+        &self.0
+    }
 }
 
 impl PrivateKey {
+    /// Generates a new private key from the provided RNG
     pub fn generate<R: Rng>(rng: &mut R) -> PrivateKey {
-        PrivateKey { sk: Fr::rand(rng) }
+        PrivateKey(Fr::rand(rng))
     }
 
-    pub fn from_sk(sk: &Fr) -> PrivateKey {
-        PrivateKey { sk: sk.clone() }
-    }
-
-    pub fn get_sk(&self) -> Fr {
-        self.sk.clone()
-    }
-
+    /// Hashes the message/extra_data tuple with the provided `hash_to_g1` function
+    /// and then signs it in the SIG_DOMAIN
     pub fn sign<H: HashToG1>(
         &self,
         message: &[u8],
@@ -40,6 +46,8 @@ impl PrivateKey {
         self.sign_message(SIG_DOMAIN, message, extra_data, hash_to_g1)
     }
 
+    /// Hashes the message/extra_data tuple with the provided `hash_to_g1` function
+    /// and then signs it in the POP_DOMAIN
     pub fn sign_pop<H: HashToG1>(
         &self,
         message: &[u8],
@@ -48,6 +56,7 @@ impl PrivateKey {
         self.sign_message(POP_DOMAIN, &message, &[], hash_to_g1)
     }
 
+    /// Hashes to G1 and signs the hash
     fn sign_message<H: HashToG1>(
         &self,
         domain: &[u8],
@@ -55,22 +64,24 @@ impl PrivateKey {
         extra_data: &[u8],
         hash_to_g1: &H,
     ) -> Result<Signature, Box<dyn Error>> {
-        Ok(Signature::from_sig(
-            hash_to_g1
-                .hash::<Bls12_377Parameters>(domain, message, extra_data)?
-                .mul(self.sk),
-        ))
+        let hash = hash_to_g1.hash::<Bls12_377Parameters>(domain, message, extra_data)?;
+        Ok(self.sign_raw(&hash))
     }
 
+    fn sign_raw(&self, message: &G1Projective) -> Signature {
+        message.mul(self.as_ref()).into()
+    }
+
+    /// Converts the private key to a public key
     pub fn to_public(&self) -> PublicKey {
-        PublicKey::from_pk(G2Projective::prime_subgroup_generator().mul(self.sk))
+        PublicKey::from(self)
     }
 }
 
 impl ToBytes for PrivateKey {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.sk.write(&mut writer)
+        self.0.write(&mut writer)
     }
 }
 
@@ -78,7 +89,7 @@ impl FromBytes for PrivateKey {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         let sk = Fr::read(&mut reader)?;
-        Ok(PrivateKey::from_sk(&sk))
+        Ok(PrivateKey::from(sk))
     }
 }
 

--- a/crates/bls-crypto/src/bls/signature.rs
+++ b/crates/bls-crypto/src/bls/signature.rs
@@ -7,7 +7,8 @@ use algebra::{
     },
     bytes::{FromBytes, ToBytes},
     curves::SWModelParameters,
-    AffineCurve, Field, One, PairingEngine, PrimeField, ProjectiveCurve, SquareRootField, Zero,
+    AffineCurve, CanonicalDeserialize, CanonicalSerialize, Field, One, PairingEngine, PrimeField,
+    ProjectiveCurve, SerializationError, SquareRootField, Zero,
 };
 use std::borrow::Borrow;
 
@@ -21,6 +22,34 @@ use super::{BLSError, PublicKey};
 #[derive(Clone, Debug, PartialEq)]
 pub struct Signature {
     sig: G1Projective,
+}
+
+impl CanonicalSerialize for Signature {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+        self.sig.into_affine().serialize(writer)
+    }
+
+    fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
+        self.sig.into_affine().serialize_uncompressed(writer)
+    }
+
+    fn serialized_size(&self) -> usize {
+        self.sig.into_affine().serialized_size()
+    }
+}
+
+impl CanonicalDeserialize for Signature {
+    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+        Ok(Signature::from_sig(
+            G1Affine::deserialize(reader)?.into_projective(),
+        ))
+    }
+
+    fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
+        Ok(Signature::from_sig(
+            G1Affine::deserialize_uncompressed(reader)?.into_projective(),
+        ))
+    }
 }
 
 impl Signature {

--- a/crates/bls-crypto/src/bls/signature.rs
+++ b/crates/bls-crypto/src/bls/signature.rs
@@ -19,56 +19,59 @@ use std::{
 
 use super::{BLSError, PublicKey};
 
+/// A BLS signature on G1.
 #[derive(Clone, Debug, PartialEq)]
-pub struct Signature {
-    sig: G1Projective,
+pub struct Signature(G1Projective);
+
+impl From<G1Projective> for Signature {
+    fn from(sig: G1Projective) -> Signature {
+        Signature(sig)
+    }
+}
+
+impl AsRef<G1Projective> for Signature {
+    fn as_ref(&self) -> &G1Projective {
+        &self.0
+    }
 }
 
 impl CanonicalSerialize for Signature {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        self.sig.into_affine().serialize(writer)
+        self.0.into_affine().serialize(writer)
     }
 
     fn serialize_uncompressed<W: Write>(&self, writer: &mut W) -> Result<(), SerializationError> {
-        self.sig.into_affine().serialize_uncompressed(writer)
+        self.0.into_affine().serialize_uncompressed(writer)
     }
 
     fn serialized_size(&self) -> usize {
-        self.sig.into_affine().serialized_size()
+        self.0.into_affine().serialized_size()
     }
 }
 
 impl CanonicalDeserialize for Signature {
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        Ok(Signature::from_sig(
+        Ok(Signature::from(
             G1Affine::deserialize(reader)?.into_projective(),
         ))
     }
 
     fn deserialize_uncompressed<R: Read>(reader: &mut R) -> Result<Self, SerializationError> {
-        Ok(Signature::from_sig(
+        Ok(Signature::from(
             G1Affine::deserialize_uncompressed(reader)?.into_projective(),
         ))
     }
 }
 
 impl Signature {
-    pub fn from_sig(sig: G1Projective) -> Signature {
-        Signature { sig }
-    }
-
-    pub fn get_sig(&self) -> G1Projective {
-        self.sig
-    }
-
     /// Sums the provided signatures to produce the aggregate signature.
-    pub fn aggregate<S: Borrow<Signature>>(signatures: &[S]) -> Signature {
+    pub fn aggregate<S: Borrow<Signature>>(signatures: impl IntoIterator<Item = S>) -> Signature {
         let mut asig = G1Projective::zero();
-        for i in signatures.iter() {
-            asig = asig + &(*i).borrow().sig;
+        for sig in signatures {
+            asig = asig + sig.borrow().as_ref();
         }
 
-        Signature { sig: asig }
+        asig.into()
     }
 
     /// Verifies the signature against a vector of pubkey & message tuples, for the provided
@@ -113,7 +116,7 @@ impl Signature {
     ) -> Result<(), BLSError> {
         // `.into()` is needed to prepared the points
         let mut els = vec![(
-            self.get_sig().into_affine().into(),
+            self.as_ref().into_affine().into(),
             G2Affine::prime_subgroup_generator().neg().into(),
         )];
         message_hashes
@@ -122,7 +125,7 @@ impl Signature {
             .for_each(|(hash, pubkey)| {
                 els.push((
                     hash.into_affine().into(),
-                    pubkey.borrow().get_pk().into_affine().into(),
+                    pubkey.borrow().as_ref().into_affine().into(),
                 ));
             });
 
@@ -138,7 +141,7 @@ impl Signature {
 impl ToBytes for Signature {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        let affine = self.sig.into_affine();
+        let affine = self.0.into_affine();
         let mut x_bytes: Vec<u8> = vec![];
         let y_big = affine.y.into_repr();
         let half = Fq::modulus_minus_one_div_two();
@@ -171,7 +174,7 @@ impl FromBytes for Signature {
         let negy = -y;
         let chosen_y = if (y <= negy) ^ y_over_half { y } else { negy };
         let sig = G1Affine::new(x, chosen_y, false);
-        Ok(Signature::from_sig(sig.into_projective()))
+        Ok(Signature::from(sig.into_projective()))
     }
 }
 
@@ -274,17 +277,17 @@ mod tests {
                 let sk = PrivateKey::generate(rng);
                 let s = sk.sign(&msgs[i].0, &msgs[i].1, &try_and_increment).unwrap();
 
-                epoch_sig += s.sig;
+                epoch_sig += s.as_ref();
                 epoch_pubkey += sk.to_public().as_ref();
             }
 
-            pubkeys.push(PublicKey::from_pk(epoch_pubkey));
-            sigs.push(Signature::from_sig(epoch_sig));
+            pubkeys.push(PublicKey::from(epoch_pubkey));
+            sigs.push(Signature::from(epoch_sig));
 
             asig += epoch_sig;
         }
 
-        let asig = Signature::from_sig(asig);
+        let asig = Signature::from(asig);
 
         let res = asig.batch_verify(&pubkeys, SIG_DOMAIN, &msgs, &try_and_increment);
 
@@ -337,7 +340,7 @@ mod tests {
         let aggregate_pubkeys = public_keys_batches
             .iter()
             .map(|pks| sum(pks))
-            .map(PublicKey::from_pk)
+            .map(PublicKey::from)
             .collect::<Vec<_>>();
 
         // the keys from each epoch sign the messages from the corresponding epoch
@@ -345,7 +348,7 @@ mod tests {
 
         // get the complete aggregate signature
         let asig = sum(&asigs);
-        let asig = Signature::from_sig(asig);
+        let asig = Signature::from(asig);
 
         let res = asig.batch_verify_hashes(&aggregate_pubkeys, &messages);
 

--- a/crates/epoch-snark/src/api/ffi/utils.rs
+++ b/crates/epoch-snark/src/api/ffi/utils.rs
@@ -68,7 +68,7 @@ unsafe fn read_serialized_pubkeys<'a>(ptr: *const u8, num: usize) -> &'a [u8] {
 pub fn serialize_pubkeys(pubkeys: &[PublicKey]) -> Result<Vec<u8>, EncodingError> {
     let mut v = Vec::new();
     for p in pubkeys {
-        p.get_pk().into_affine().serialize(&mut v)?
+        p.as_ref().into_affine().serialize(&mut v)?
     }
     Ok(v)
 }
@@ -85,7 +85,7 @@ unsafe fn read_pubkeys(ptr: *const u8, num: usize) -> Result<Vec<PublicKey>, Enc
     for _ in 0..num {
         let key = G2Affine::deserialize(&mut data)?;
         let key = key.into_projective();
-        pubkeys.push(PublicKey::from_pk(key))
+        pubkeys.push(PublicKey::from(key))
     }
     Ok(pubkeys)
 }
@@ -197,7 +197,7 @@ mod tests {
         G2Projective::batch_normalization(&mut points);
         points
             .iter()
-            .map(|p| PublicKey::from_pk(*p))
+            .map(|p| PublicKey::from(*p))
             .collect::<Vec<_>>()
     }
 }

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -50,14 +50,12 @@ pub fn prove(
     };
 
     // Generate the BLS proof
-    let asig = transitions.iter().fold(G1Projective::zero(), |acc, epoch| {
-        acc + epoch.aggregate_signature.get_sig()
-    });
+    let asig = Signature::aggregate(transitions.iter().map(|epoch| &epoch.aggregate_signature));
 
     let circuit = ValidatorSetUpdate::<BLSCurve> {
         initial_epoch: to_epoch_data(initial_epoch),
         epochs,
-        aggregated_signature: Some(asig),
+        aggregated_signature: Some(*asig.as_ref()),
         num_validators,
         hash_helper,
     };
@@ -117,7 +115,7 @@ pub fn to_epoch_data(block: &EpochBlock) -> EpochData<BLSCurve> {
         public_keys: block
             .new_public_keys
             .iter()
-            .map(|pubkey| Some(pubkey.get_pk()))
+            .map(|pubkey| Some(*pubkey.as_ref()))
             .collect(),
     }
 }

--- a/crates/epoch-snark/src/encoding.rs
+++ b/crates/epoch-snark/src/encoding.rs
@@ -19,7 +19,7 @@ pub enum EncodingError {
 /// The function assumes that the public key is not the point in infinity, which is true for
 /// BLS public keys
 pub fn encode_public_key(public_key: &PublicKey) -> Result<Vec<bool>, EncodingError> {
-    let pk_affine = public_key.get_pk().into_affine();
+    let pk_affine = public_key.as_ref().into_affine();
     let x = pk_affine.x;
     let y = pk_affine.y;
 

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -227,7 +227,7 @@ mod tests {
         let epoch = test_epoch(10);
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
-            pubkeys.push(PublicKey::from_pk(pk.unwrap()));
+            pubkeys.push(PublicKey::from(pk.unwrap()));
         }
 
         // Calculate the hash from our to_bytes function
@@ -269,7 +269,7 @@ mod tests {
         let epoch = test_epoch(18);
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
-            pubkeys.push(PublicKey::from_pk(pk.unwrap()));
+            pubkeys.push(PublicKey::from(pk.unwrap()));
         }
 
         // calculate the bits from our helper function

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -39,7 +39,7 @@ pub mod test_helpers {
     pub fn hash_epoch(epoch: &EpochData<Bls12_377>) -> G1Projective {
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
-            pubkeys.push(PublicKey::from_pk(pk.unwrap()));
+            pubkeys.push(PublicKey::from(pk.unwrap()));
         }
 
         // Calculate the hash from our to_bytes function

--- a/crates/epoch-snark/tests/fixtures.rs
+++ b/crates/epoch-snark/tests/fixtures.rs
@@ -20,7 +20,7 @@ pub fn generate_test_data(
     let initial_pubkeys = initial_validator_set
         .1
         .iter()
-        .map(|pk| PublicKey::from_pk(*pk))
+        .map(|pk| PublicKey::from(*pk))
         .collect::<Vec<_>>();
     let first_epoch = generate_block(0, faults, &initial_pubkeys);
 
@@ -30,12 +30,7 @@ pub fn generate_test_data(
     let pubkeys = validators
         .1
         .iter()
-        .map(|epoch_keys| {
-            epoch_keys
-                .iter()
-                .map(|pk| PublicKey::from_pk(*pk))
-                .collect()
-        })
+        .map(|epoch_keys| epoch_keys.iter().map(|pk| PublicKey::from(*pk)).collect())
         .collect::<Vec<Vec<_>>>();
 
     // Signers will be from the 1st to the last-1 epoch
@@ -58,7 +53,7 @@ pub fn generate_test_data(
             }
             asig
         };
-        let asig = Signature::from_sig(asig);
+        let asig = Signature::from(asig);
 
         let transition = EpochTransition {
             block,


### PR DESCRIPTION
Adds zexe serialization for our basic crypto types. Depends on https://github.com/celo-org/bls-zexe/pull/135.