### PR TITLE
Fixes point compression logic and uses upstream Zexe logic instead

### DIFF
--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -1,20 +1,17 @@
 use crate::{BLSError, HashToCurve, PrivateKey, PublicKeyCache, Signature, POP_DOMAIN, SIG_DOMAIN};
 
 use algebra::{
-    bls12_377::{
-        Bls12_377, Fq12, G1Projective, G2Affine,
-        G2Projective,
-    },
+    bls12_377::{Bls12_377, Fq12, G1Projective, G2Affine, G2Projective},
     bytes::{FromBytes, ToBytes},
-    AffineCurve, CanonicalDeserialize, CanonicalSerialize, One, PairingEngine,
-    ProjectiveCurve, SerializationError,Zero,
+    AffineCurve, CanonicalDeserialize, CanonicalSerialize, One, PairingEngine, ProjectiveCurve,
+    SerializationError, Zero,
 };
 use std::hash::{Hash, Hasher};
 
 use crate::BlsResult;
 
 use std::{
-    io::{self, Read, Result as IoResult, Write, Cursor},
+    io::{self, Cursor, Read, Result as IoResult, Write},
     ops::Neg,
 };
 
@@ -50,7 +47,8 @@ impl PublicKey {
     }
 
     pub fn from_vec(data: &Vec<u8>) -> IoResult<PublicKey> {
-        PublicKey::deserialize(&mut Cursor::new(data)).map_err(|_| io::ErrorKind::InvalidInput.into())
+        PublicKey::deserialize(&mut Cursor::new(data))
+            .map_err(|_| io::ErrorKind::InvalidInput.into())
     }
 
     pub fn verify<H: HashToCurve<Output = G1Projective>>(
@@ -125,7 +123,8 @@ impl Hash for PublicKey {
 impl ToBytes for PublicKey {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        self.serialize(&mut writer).map_err(|_| io::ErrorKind::InvalidInput.into())
+        self.serialize(&mut writer)
+            .map_err(|_| io::ErrorKind::InvalidInput.into())
     }
 }
 
@@ -170,12 +169,12 @@ impl CanonicalDeserialize for PublicKey {
 mod test {
     use super::*;
     use crate::bls::PrivateKey;
-    use rand::thread_rng;
     use algebra::{
-        fields::{Field, PrimeField, SquareRootField},
-        curves::SWModelParameters,
         bls12_377::{g2::Parameters as Bls12_377G2Parameters, Fq, Fq2},
+        curves::SWModelParameters,
+        fields::{Field, PrimeField, SquareRootField},
     };
+    use rand::thread_rng;
     use std::io::{self, Result as IoResult, Write};
 
     #[test]
@@ -241,7 +240,7 @@ mod test {
             let sk = PrivateKey::generate(rng);
             let pk = sk.to_public();
             if pk.as_ref().into_affine().y.c1 == Fq::zero() {
-                continue
+                continue;
             }
 
             let mut pk_bytes = vec![];
@@ -267,10 +266,9 @@ mod test {
 
             i += 1;
             if i == 1000 {
-                break
+                break;
             }
         }
-
 
         // check cases where c1 = 0
         for _ in 0..1000 {

--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -11,7 +11,7 @@ use std::hash::{Hash, Hasher};
 use crate::BlsResult;
 
 use std::{
-    io::{self, Cursor, Read, Result as IoResult, Write},
+    io::{self, Read, Result as IoResult, Write},
     ops::Neg,
 };
 
@@ -47,8 +47,7 @@ impl PublicKey {
     }
 
     pub fn from_vec(data: &Vec<u8>) -> IoResult<PublicKey> {
-        PublicKey::deserialize(&mut Cursor::new(data))
-            .map_err(|_| io::ErrorKind::InvalidInput.into())
+        PublicKey::deserialize(&mut &data[..]).map_err(|_| io::ErrorKind::InvalidInput.into())
     }
 
     pub fn verify<H: HashToCurve<Output = G1Projective>>(

--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -2,20 +2,19 @@ use crate::{BLSError, HashToCurve, PrivateKey, PublicKeyCache, Signature, POP_DO
 
 use algebra::{
     bls12_377::{
-        g2::Parameters as Bls12_377G2Parameters, Bls12_377, Fq, Fq12, Fq2, G1Projective, G2Affine,
+        Bls12_377, Fq12, G1Projective, G2Affine,
         G2Projective,
     },
     bytes::{FromBytes, ToBytes},
-    curves::SWModelParameters,
-    AffineCurve, CanonicalDeserialize, CanonicalSerialize, Field, One, PairingEngine, PrimeField,
-    ProjectiveCurve, SerializationError, SquareRootField, Zero,
+    AffineCurve, CanonicalDeserialize, CanonicalSerialize, One, PairingEngine,
+    ProjectiveCurve, SerializationError,Zero,
 };
 use std::hash::{Hash, Hasher};
 
 use crate::BlsResult;
 
 use std::{
-    io::{self, Read, Result as IoResult, Write},
+    io::{self, Read, Result as IoResult, Write, Cursor},
     ops::Neg,
 };
 
@@ -51,38 +50,7 @@ impl PublicKey {
     }
 
     pub fn from_vec(data: &Vec<u8>) -> IoResult<PublicKey> {
-        let mut x_bytes_with_y: Vec<u8> = data.to_owned();
-        let x_bytes_with_y_len = x_bytes_with_y.len();
-        let y_over_half = (x_bytes_with_y[x_bytes_with_y_len - 1] & 0x80) == 0x80;
-        x_bytes_with_y[x_bytes_with_y_len - 1] &= 0xFF - 0x80;
-        let x = Fq2::read(x_bytes_with_y.as_slice())?;
-        let x3b = <Bls12_377G2Parameters as SWModelParameters>::add_b(
-            &((x.square() * &x) + &<Bls12_377G2Parameters as SWModelParameters>::mul_by_a(&x)),
-        );
-        let y = x3b.sqrt().ok_or(io::Error::new(
-            io::ErrorKind::NotFound,
-            "couldn't find square root for x",
-        ))?;
-
-        let y_c0_big = y.c0.into_repr();
-        let y_c1_big = y.c1.into_repr();
-
-        let negy = -y;
-
-        let (bigger, smaller) = {
-            let half = Fq::modulus_minus_one_div_two();
-            if y_c1_big > half {
-                (y, negy)
-            } else if y_c1_big == half && y_c0_big > half {
-                (y, negy)
-            } else {
-                (negy, y)
-            }
-        };
-
-        let chosen_y = if y_over_half { bigger } else { smaller };
-        let pk = G2Affine::new(x, chosen_y, false);
-        Ok(PublicKey::from(pk.into_projective()))
+        PublicKey::deserialize(&mut Cursor::new(data)).map_err(|_| io::ErrorKind::InvalidInput.into())
     }
 
     pub fn verify<H: HashToCurve<Output = G1Projective>>(
@@ -157,21 +125,7 @@ impl Hash for PublicKey {
 impl ToBytes for PublicKey {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        let affine = self.0.into_affine();
-        let mut x_bytes: Vec<u8> = vec![];
-        let y_c0_big = affine.y.c0.into_repr();
-        let y_c1_big = affine.y.c1.into_repr();
-        let half = Fq::modulus_minus_one_div_two();
-        affine.x.write(&mut x_bytes)?;
-        let num_x_bytes = x_bytes.len();
-        if y_c1_big > half {
-            x_bytes[num_x_bytes - 1] |= 0x80;
-        } else if y_c1_big == half && y_c0_big > half {
-            x_bytes[num_x_bytes - 1] |= 0x80;
-        }
-        writer.write(&x_bytes)?;
-
-        Ok(())
+        self.serialize(&mut writer).map_err(|_| io::ErrorKind::InvalidInput.into())
     }
 }
 
@@ -217,16 +171,78 @@ mod test {
     use super::*;
     use crate::bls::PrivateKey;
     use rand::thread_rng;
+    use algebra::{
+        fields::{Field, PrimeField, SquareRootField},
+        curves::SWModelParameters,
+        bls12_377::{g2::Parameters as Bls12_377G2Parameters, Fq, Fq2},
+    };
+    use std::io::{self, Result as IoResult, Write};
 
     #[test]
     fn test_public_key_serialization() {
         PublicKeyCache::resize(256);
         PublicKeyCache::clear_cache();
 
+        let old_serialization_logic = |pk: PublicKey, writer: &mut Vec<u8>| -> IoResult<_> {
+            let affine = pk.0.into_affine();
+            let mut x_bytes: Vec<u8> = vec![];
+            let y_c0_big = affine.y.c0.into_repr();
+            let y_c1_big = affine.y.c1.into_repr();
+            let half = Fq::modulus_minus_one_div_two();
+            affine.x.write(&mut x_bytes)?;
+            let num_x_bytes = x_bytes.len();
+            if y_c1_big > half {
+                x_bytes[num_x_bytes - 1] |= 0x80;
+            } else if y_c1_big == half && y_c0_big > half {
+                x_bytes[num_x_bytes - 1] |= 0x80;
+            }
+            writer.write(&x_bytes)?;
+
+            Ok(())
+        };
+
+        let old_deserialization_logic = |data: &[u8]| -> IoResult<_> {
+            let mut x_bytes_with_y: Vec<u8> = data.to_owned();
+            let x_bytes_with_y_len = x_bytes_with_y.len();
+            let y_over_half = (x_bytes_with_y[x_bytes_with_y_len - 1] & 0x80) == 0x80;
+            x_bytes_with_y[x_bytes_with_y_len - 1] &= 0xFF - 0x80;
+            let x = Fq2::read(x_bytes_with_y.as_slice())?;
+            let x3b = <Bls12_377G2Parameters as SWModelParameters>::add_b(
+                &((x.square() * &x) + &<Bls12_377G2Parameters as SWModelParameters>::mul_by_a(&x)),
+            );
+            let y = x3b.sqrt().ok_or(io::Error::new(
+                io::ErrorKind::NotFound,
+                "couldn't find square root for x",
+            ))?;
+
+            let y_c0_big = y.c0.into_repr();
+            let y_c1_big = y.c1.into_repr();
+
+            let negy = -y;
+
+            let (bigger, smaller) = {
+                let half = Fq::modulus_minus_one_div_two();
+                if y_c1_big > half {
+                    (y, negy)
+                } else if y_c1_big == half && y_c0_big > half {
+                    (y, negy)
+                } else {
+                    (negy, y)
+                }
+            };
+
+            let chosen_y = if y_over_half { bigger } else { smaller };
+            Ok((x, chosen_y))
+        };
+
         let rng = &mut thread_rng();
-        for _ in 0..100 {
+        let mut i = 0;
+        loop {
             let sk = PrivateKey::generate(rng);
             let pk = sk.to_public();
+            if pk.as_ref().into_affine().y.c1 == Fq::zero() {
+                continue
+            }
 
             let mut pk_bytes = vec![];
             pk.write(&mut pk_bytes).unwrap();
@@ -234,7 +250,11 @@ mod test {
             let mut pk_bytes2 = vec![];
             pk.serialize(&mut pk_bytes2).unwrap();
 
+            let mut pk_bytes3 = vec![];
+            old_serialization_logic(pk, &mut pk_bytes3).unwrap();
+
             assert_eq!(pk_bytes, pk_bytes2);
+            assert_eq!(pk_bytes, pk_bytes3);
 
             let de_pk = PublicKey::read(&pk_bytes[..]).unwrap();
             let de_pk2 = PublicKey::deserialize(&mut &pk_bytes[..]).unwrap();
@@ -244,6 +264,52 @@ mod test {
             // check that the points match (the PartialEq does only bytes equality)
             assert_eq!(de_pk.as_ref().x, de_pk2.as_ref().x);
             assert_eq!(de_pk.as_ref().y, de_pk2.as_ref().y);
+
+            i += 1;
+            if i == 1000 {
+                break
+            }
+        }
+
+
+        // check cases where c1 = 0
+        for _ in 0..1000 {
+            let sk = PrivateKey::generate(rng);
+            let pk = sk.to_public();
+            let mut pk_affine = pk.as_ref().into_affine();
+            pk_affine.y.c1 = Fq::zero();
+            let pk = PublicKey::from(pk_affine.into_projective());
+
+            let mut pk_bytes = vec![];
+            pk.write(&mut pk_bytes).unwrap();
+
+            let mut pk_bytes2 = vec![];
+            pk.serialize(&mut pk_bytes2).unwrap();
+
+            let mut pk_bytes3 = vec![];
+            old_serialization_logic(pk, &mut pk_bytes3).unwrap();
+
+            assert_eq!(pk_bytes, pk_bytes2);
+            // check for the bug mentioned in https://github.com/celo-org/bls-zexe/issues/149
+            if pk_affine.y > pk_affine.y.neg() {
+                assert_ne!(pk_bytes, pk_bytes3);
+            } else {
+                assert_eq!(pk_bytes, pk_bytes3);
+            }
+
+            let de_pk = PublicKey::read(&pk_bytes[..]).unwrap();
+            let de_pk2 = PublicKey::deserialize(&mut &pk_bytes[..]).unwrap();
+
+            assert_eq!(de_pk, de_pk2);
+
+            // check that the points match (the PartialEq does only bytes equality)
+            assert_eq!(de_pk.as_ref().x, de_pk2.as_ref().x);
+            assert_eq!(de_pk.as_ref().y, de_pk2.as_ref().y);
+
+            let pk_affine = de_pk.0.into_affine();
+            let (x, y) = old_deserialization_logic(&pk_bytes[..]).unwrap();
+            assert_eq!(x, pk_affine.x);
+            assert_eq!(y, pk_affine.y);
         }
     }
 }

--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -237,13 +237,16 @@ mod test {
         };
 
         let rng = &mut thread_rng();
-        let mut i = 0;
-        // check cases where c1 != 0
-        loop {
+        // Check cases where c1 != 0, which are the normal case.
+        for _ in 0..1000 {
             let sk = PrivateKey::generate(rng);
             let pk = sk.to_public();
             if pk.as_ref().into_affine().y.c1 == Fq::zero() {
-                continue;
+                // If it happens, we want to know about it.
+                panic!(format!(
+                    "point had c1 = 0! point was: {}",
+                    pk.as_ref().into_affine()
+                ));
             }
 
             let mut pk_bytes = vec![];
@@ -266,14 +269,10 @@ mod test {
             // check that the points match (the PartialEq does only bytes equality)
             assert_eq!(de_pk.as_ref().x, de_pk2.as_ref().x);
             assert_eq!(de_pk.as_ref().y, de_pk2.as_ref().y);
-
-            i += 1;
-            if i == 1000 {
-                break;
-            }
         }
 
-        // check cases where c1 = 0
+        // Check cases where c1 = 0. These don't occur normally and in fact the manually patched
+        // points are not on the curve.
         for _ in 0..1000 {
             let sk = PrivateKey::generate(rng);
             let pk = sk.to_public();


### PR DESCRIPTION
### Description

Fixes https://github.com/celo-org/bls-zexe/issues/149.

Adds tests that the old serialization/deserialization logic matches the new implementation, besides the problematic cases.