### PR TITLE
Adds compat mode to support the deployed Celo blockchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ jobs:
           command: cargo test --release
           no_output_timeout: 30m
       - run:
+          name: Run compat tests
+          command: cd crates/bls-crypto && cargo test --release --features compat
+          no_output_timeout: 30m
+      - run:
           name: Check Style
           command: |
             cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,6 @@ dependencies = [
  "bench-utils",
  "blake2s_simd",
  "byteorder",
- "cfg-if",
  "clap",
  "criterion",
  "crypto-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "bench-utils",
  "blake2s_simd",
  "byteorder",
+ "cfg-if",
  "clap",
  "criterion",
  "crypto-primitives",

--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -22,6 +22,7 @@ csv = "1.1"
 rand_chacha = "0.2.1"
 thiserror = "1.0.14"
 once_cell = "1.3.1"
+cfg-if = "0.1.10"
 
 [dev-dependencies]
 criterion = "0.2"
@@ -44,3 +45,4 @@ crate-type = ["lib", "staticlib"]
 
 [features]
 test-helpers = []
+compat = []

--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -22,7 +22,6 @@ csv = "1.1"
 rand_chacha = "0.2.1"
 thiserror = "1.0.14"
 once_cell = "1.3.1"
-cfg-if = "0.1.10"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -249,7 +249,7 @@ mod compat_tests {
     ) -> Option<G1Affine<P>> {
         // Compute x^3 + ax + b
         let x3b = <P::G1Parameters as SWModelParameters>::add_b(
-            &((x.square() * x) + <P::G1Parameters as SWModelParameters>::mul_by_a(&x)),
+            &((x.square() * &x) + &<P::G1Parameters as SWModelParameters>::mul_by_a(&x)),
         );
 
         x3b.sqrt().map(|y| {

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -226,6 +226,8 @@ mod test {
 
 #[cfg(all(test, feature = "compat"))]
 mod compat_tests {
+    #![allow(clippy::op_ref)]
+
     use super::*;
     use algebra::{
         curves::models::{

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -249,7 +249,7 @@ mod compat_tests {
     ) -> Option<G1Affine<P>> {
         // Compute x^3 + ax + b
         let x3b = <P::G1Parameters as SWModelParameters>::add_b(
-            &((x.square() * &x) + &<P::G1Parameters as SWModelParameters>::mul_by_a(&x)),
+            &((x.square() * x) + <P::G1Parameters as SWModelParameters>::mul_by_a(&x)),
         );
 
         x3b.sqrt().map(|y| {
@@ -323,7 +323,7 @@ mod compat_tests {
                 }
             }
         }
-        Err(BLSError::HashToCurveError)?
+        Err(BLSError::HashToCurveError)
     }
 
     fn generate_compat_expected_hashes(num_expected_hashes: usize) -> Vec<Vec<u8>> {

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -1,6 +1,5 @@
 use bench_utils::{end_timer, start_timer};
 use byteorder::WriteBytesExt;
-use hex;
 use log::trace;
 use std::marker::PhantomData;
 

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -342,7 +342,7 @@ mod compat_tests {
     #[test]
     fn test_hash_to_curve_g1() {
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
-        let expected_hashes = generate_compat_expected_hashes(10);
+        let expected_hashes = generate_compat_expected_hashes(1000);
 
         let hasher = TryAndIncrement::<_, <Parameters as Bls12Parameters>::G1Parameters>::new(&*COMPOSITE_HASHER);
         super::test::test_hash_to_group(&hasher, &mut rng, expected_hashes)


### PR DESCRIPTION
### Description

The deployed Celo version's hash-to-curve takes the sign bit from a different position than the upstream Zexe logic. This PR adds a compatibility mode that allows to use the upstream Zexe version by patching the appropriate bits.

### Tested

Adds tests with the old hasher and compares results.