### PR TITLE
test(cache): add tests and improve PublicKey PartialEq

### DIFF
--- a/crates/bls-crypto/src/bls/cache.rs
+++ b/crates/bls-crypto/src/bls/cache.rs
@@ -2,14 +2,20 @@ use super::PublicKey;
 use algebra::{bls12_377::G2Projective, CanonicalDeserialize, SerializationError, Zero};
 
 use lru::LruCache;
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
+/// Allows deserializing and aggregation of public keys while holding a cache to improve
+/// performance. Aggregation assumes that the aggregated public key changes slowly.
 pub struct PublicKeyCache {
     /// The current keys in the validator set
-    pub keys: HashSet<PublicKey>,
+    keys: HashSet<WrappedPublicKey>,
     /// The aggregated public key of all validators
     pub combined: PublicKey,
-    /// A mapping from
+    /// An in-memory mapping of serialized pubkey byte arrays to their deserialized
+    /// group element representation
     pub de: LruCache<Vec<u8>, PublicKey>,
 }
 
@@ -55,24 +61,106 @@ impl PublicKeyCache {
     /// The set of public keys changes slowly, so for speed this method computes the
     /// difference from the last call and does an incremental update of the combined key
     pub fn aggregate(&mut self, public_keys: Vec<PublicKey>) -> PublicKey {
-        let mut keys: HashSet<PublicKey> = HashSet::with_capacity(public_keys.len());
+        let mut keys: HashSet<WrappedPublicKey> = HashSet::with_capacity(public_keys.len());
         for key in public_keys {
-            keys.insert(key);
+            keys.insert(WrappedPublicKey(key));
         }
 
         let mut combined = self.combined.0;
 
+        // Subtract any keys which are no longer present
         for key in self.keys.difference(&keys) {
-            combined -= key.as_ref();
+            combined -= key.0.as_ref();
         }
 
+        // Add the new keys
         for key in keys.difference(&self.keys) {
-            combined += key.as_ref();
+            combined += key.0.as_ref();
         }
 
         self.keys = keys;
         self.combined = PublicKey(combined);
 
         self.combined.clone()
+    }
+}
+
+// Helper type with faster equality semantics when used with HashSet
+#[derive(Eq, Clone, Debug)]
+struct WrappedPublicKey(PublicKey);
+
+impl PartialEq for WrappedPublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        // This byte-level equality operator differs from the (much slower) semantic
+        // equality operator in G2Projective.  We require byte-level equality here
+        // for HashSet to work correctly.  HashSet requires that item equality
+        // implies hash equality.
+        let a = self.0.as_ref();
+        let b = other.0.as_ref();
+        a.x == b.x && a.y == b.y && a.z == b.z
+    }
+}
+
+impl Hash for WrappedPublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Only hash based on `y` for slight speed improvement
+        self.0.as_ref().y.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use algebra::{CanonicalSerialize, UniformRand};
+
+    fn rand_pubkey() -> PublicKey {
+        PublicKey(G2Projective::rand(&mut rand::thread_rng()))
+    }
+
+    #[test]
+    fn deserializer() {
+        let mut cache = PublicKeyCache::new();
+
+        let pubkeys = (0..10).map(|_| rand_pubkey()).collect::<Vec<_>>();
+        let serialized = pubkeys
+            .iter()
+            .map(|p| {
+                let mut w = vec![];
+                p.serialize(&mut w).unwrap();
+                w
+            })
+            .collect::<Vec<_>>();
+
+        let de = serialized
+            .iter()
+            .map(|ser| cache.deserialize(ser.clone()).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(de, pubkeys);
+    }
+
+    #[test]
+    fn caches_deserialized_pubkeys() {
+        let mut cache = PublicKeyCache::new();
+
+        let pubkey = rand_pubkey();
+
+        let mut serialized = vec![];
+        pubkey.serialize(&mut serialized).unwrap();
+
+        assert!(cache.de.is_empty());
+
+        cache.deserialize(serialized.clone()).unwrap();
+
+        assert_eq!(cache.de.get(&serialized).unwrap(), &pubkey);
+    }
+
+    #[test]
+    fn aggregation() {
+        let mut cache = PublicKeyCache::new();
+
+        let pubkeys = (0..10).map(|_| rand_pubkey()).collect::<Vec<_>>();
+
+        let apubkey = cache.aggregate(pubkeys.clone());
+        assert_eq!(apubkey, PublicKey::aggregate(&pubkeys));
     }
 }

--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -7,13 +7,12 @@ use algebra::{
 };
 
 use std::{
-    hash::{Hash, Hasher},
     io::{Read, Write},
     ops::Neg,
 };
 
 /// A BLS public key on G2
-#[derive(Clone, Eq, Debug)]
+#[derive(Clone, Eq, Debug, PartialEq, Hash)]
 pub struct PublicKey(pub(super) G2Projective);
 
 impl From<G2Projective> for PublicKey {
@@ -88,27 +87,6 @@ impl PublicKey {
         } else {
             Err(BLSError::VerificationFailed)
         }
-    }
-}
-
-impl PartialEq for PublicKey {
-    fn eq(&self, other: &Self) -> bool {
-        // This byte-level equality operator differs from the (much slower) semantic
-        // equality operator in G2Projective.  We require byte-level equality here
-        // for HashSet to work correctly.  HashSet requires that item equality
-        // implies hash equality.
-        let a = self.as_ref();
-        let b = other.as_ref();
-        a.x == b.x && a.y == b.y && a.z == b.z
-    }
-}
-
-impl Hash for PublicKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Only hash based on `y` for slight speed improvement
-        self.0.y.hash(state);
-        // self.pk.x.hash(state);
-        // self.pk.z.hash(state);
     }
 }
 


### PR DESCRIPTION
- Adds tests for the cache
- The cache's hashset now uses a WrappedPublicKey type which implements the byte level equality, while the normal public key derives it from its underlying group element datatype