### PR TITLE
refactor: move utility functions to their own module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Implements SNARK-friendly BLS signatures over BLS12-377 and SW6.
 
 All Rust crates live under the `crates/` directory. You can import them in your code via git paths, until they get published on `crates.io`.
 
-### Go and FFI
-
-A Go package consuming the library exists in the `go` directory, using `cgo`.
-
 ## Quick start
 
 The following commands assume your current directory is the root of this repository.

--- a/crates/bls-gadgets/src/bitmap.rs
+++ b/crates/bls-gadgets/src/bitmap.rs
@@ -1,4 +1,4 @@
-use crate::{utils::is_setup, smaller_than::SmallerThanGadget};
+use crate::{smaller_than::SmallerThanGadget, utils::is_setup};
 use algebra::PrimeField;
 use r1cs_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use r1cs_std::{

--- a/crates/bls-gadgets/src/bitmap.rs
+++ b/crates/bls-gadgets/src/bitmap.rs
@@ -1,4 +1,4 @@
-use crate::{is_setup, smaller_than::SmallerThanGadget};
+use crate::{utils::is_setup, smaller_than::SmallerThanGadget};
 use algebra::PrimeField;
 use r1cs_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use r1cs_std::{

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -268,7 +268,7 @@ where
 #[cfg(test)]
 mod verify_one_message {
     use super::*;
-    use crate::test_helpers::alloc_vec;
+    use crate::utils::test_helpers::alloc_vec;
     use bls_crypto::test_helpers::*;
 
     use algebra::{

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -8,7 +8,7 @@ use r1cs_std::{
 use std::marker::PhantomData;
 use tracing::{debug, span, trace, Level};
 
-/// BLS Signature Verification Pairing Gadget.
+/// BLS Signature Verification Gadget.
 ///
 /// Implements BLS Verification as written in [BDN18](https://eprint.iacr.org/2018/483.pdf)
 /// in a Pairing-based SNARK.

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -69,7 +69,13 @@ fn blake2xs_params(
     }
 }
 
-/// Gadget for checking that hashes to group are computed correctly
+/// Gadget which enforces correct calculation of hashing to group of arbitrary data, implementing
+/// the "try and increment" method. For more information on the method, refer to the [non-gadget
+/// implementation][hash_to_group].
+///
+/// Currently this gadget only exposes hashing to BLS12-377's G1.
+///
+/// [hash_to_group]: ../bls_crypto/hash_to_curve/try_and_increment/index.html
 pub struct HashToGroupGadget<P> {
     parameters_type: PhantomData<P>,
 }
@@ -79,9 +85,15 @@ pub struct HashToGroupGadget<P> {
 // and then hashing it to bits and to group
 impl HashToGroupGadget<Bls12_377_Parameters> {
     /// Returns the G1 constrained hash of the message with the provided counter.
-    /// We do not generate constraints for the CRH -> XOF conversion in this case,
-    /// because it is expensive to do inside SW6. We provide auxiliary date which can be
-    /// used to generate an outer proof that ensures this calculation is done correctly
+    ///
+    /// If `generate_constraints_for_hash` is set to `false`, then constraints will not
+    /// be generated for the CRH -> XOF conversion. You may want to set this to `false` if
+    /// calculations inside SW6 are considered too expensive. In that case, you MUST verify
+    /// that they were calculated properly.
+    ///
+    /// For that reason, this function also returns the CRH bits and the XOF bits,
+    /// so that they can be used to verify the correct calculation of the XOF from
+    /// the CRH in a separate proof.
     #[allow(clippy::type_complexity)]
     pub fn enforce_hash_to_group<CS: ConstraintSystem<Bls12_377_Fq>>(
         cs: &mut CS,
@@ -153,6 +165,8 @@ impl HashToGroupGadget<Bls12_377_Parameters> {
 /// This uses Blake2s under the hood and is expensive for large messages.
 /// Consider reducing the input size by passing it through a Collision Resistant Hash function
 /// such as Pedersen.
+///
+/// If `generate_constraints_for_hash = false`, then no constraints will be generated.
 ///
 /// # Panics
 ///

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -1,4 +1,7 @@
-use crate::{bits_to_bytes, bytes_to_bits, constrain_bool, is_setup, YToBitGadget};
+use crate::{
+    utils::{bits_to_bytes, bytes_to_bits, constrain_bool, is_setup},
+    YToBitGadget,
+};
 use bls_crypto::{
     hashers::{
         composite::{CompositeHasher, CRH},

--- a/crates/bls-gadgets/src/lib.rs
+++ b/crates/bls-gadgets/src/lib.rs
@@ -1,4 +1,7 @@
-//! # Gadgets
+//! # BLS Gadgets
+//!
+//! This module provides gadgets for constructing R1CS involving BLS Signatures
+//! over the BLS12-377 curve.
 
 mod bls;
 pub use bls::BlsVerifyGadget;

--- a/crates/bls-gadgets/src/lib.rs
+++ b/crates/bls-gadgets/src/lib.rs
@@ -4,7 +4,7 @@ mod bls;
 pub use bls::BlsVerifyGadget;
 
 mod bitmap;
-pub use bitmap::enforce_maximum_occurrences_in_bitmap;
+pub(crate) use bitmap::enforce_maximum_occurrences_in_bitmap;
 
 mod y_to_bit;
 pub use y_to_bit::YToBitGadget;
@@ -15,82 +15,5 @@ pub use hash_to_group::{hash_to_bits, HashToGroupGadget};
 mod smaller_than;
 pub use smaller_than::SmallerThanGadget;
 
-use algebra::Field;
-use r1cs_core::{ConstraintSystem, SynthesisError};
-use r1cs_std::{alloc::AllocGadget, boolean::Boolean};
-
-/// Helper which _must_ be used before trying to the inner values
-/// of a boolean vector
-pub fn is_setup(message: &[Boolean]) -> bool {
-    message.iter().any(|m| m.get_value().is_none())
-}
-
-pub fn constrain_bool<F: Field, CS: ConstraintSystem<F>>(
-    cs: &mut CS,
-    input: &[bool],
-) -> Result<Vec<Boolean>, SynthesisError> {
-    input
-        .iter()
-        .enumerate()
-        .map(|(j, b)| Boolean::alloc(cs.ns(|| format!("{}", j)), || Ok(b)))
-        .collect::<Result<Vec<_>, _>>()
-}
-
-pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
-    let mut bytes = vec![];
-    let reversed_bits = {
-        let mut tmp = bits.to_owned();
-        tmp.reverse();
-        tmp
-    };
-    for chunk in reversed_bits.chunks(8) {
-        let mut byte = 0;
-        let mut twoi: u64 = 1;
-        for c in chunk {
-            byte += (twoi * (*c as u64)) as u8;
-            twoi *= 2;
-        }
-        bytes.push(byte);
-    }
-
-    bytes
-}
-
-/// If bytes is a little endian representation of a number, this would return the bits of the
-/// number in descending order
-pub fn bytes_to_bits(bytes: &[u8], bits_to_take: usize) -> Vec<bool> {
-    let mut bits = vec![];
-    for b in bytes {
-        let mut byte = *b;
-        for _ in 0..8 {
-            bits.push((byte & 1) == 1);
-            byte >>= 1;
-        }
-    }
-
-    bits.into_iter()
-        .take(bits_to_take)
-        .collect::<Vec<bool>>()
-        .into_iter()
-        .rev()
-        .collect()
-}
-
-#[cfg(any(test, feature = "test-helpers"))]
-pub mod test_helpers {
-    use algebra::{Field, Group};
-    use r1cs_core::ConstraintSystem;
-    use r1cs_std::groups::GroupGadget;
-
-    /// Allocates an array of group elements to a group gadget
-    pub fn alloc_vec<F: Field, G: Group, GG: GroupGadget<G, F>, CS: ConstraintSystem<F>>(
-        cs: &mut CS,
-        elements: &[G],
-    ) -> Vec<GG> {
-        elements
-            .iter()
-            .enumerate()
-            .map(|(i, element)| GG::alloc(&mut cs.ns(|| format!("{}", i)), || Ok(element)).unwrap())
-            .collect::<Vec<_>>()
-    }
-}
+/// Utility functions which do not involve generating constraints
+pub mod utils;

--- a/crates/bls-gadgets/src/utils.rs
+++ b/crates/bls-gadgets/src/utils.rs
@@ -1,0 +1,82 @@
+use algebra::Field;
+use r1cs_core::{ConstraintSystem, SynthesisError};
+use r1cs_std::{alloc::AllocGadget, boolean::Boolean};
+
+/// Helper used to skip operations which should not be executed when running the
+/// trusted setup
+pub fn is_setup(message: &[Boolean]) -> bool {
+    message.iter().any(|m| m.get_value().is_none())
+}
+
+/// Converts the provided bits to LE bytes
+pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
+    let reversed_bits = {
+        let mut tmp = bits.to_owned();
+        tmp.reverse();
+        tmp
+    };
+
+    let mut bytes = vec![];
+    for chunk in reversed_bits.chunks(8) {
+        let mut byte = 0;
+        let mut twoi: u64 = 1;
+        for c in chunk {
+            byte += (twoi * (*c as u64)) as u8;
+            twoi *= 2;
+        }
+        bytes.push(byte);
+    }
+
+    bytes
+}
+
+/// If bytes is a little endian representation of a number, this returns the bits 
+/// of the number in descending order
+pub fn bytes_to_bits(bytes: &[u8], bits_to_take: usize) -> Vec<bool> {
+    let mut bits = vec![];
+    for b in bytes {
+        let mut byte = *b;
+        for _ in 0..8 {
+            bits.push((byte & 1) == 1);
+            byte >>= 1;
+        }
+    }
+
+    bits.into_iter()
+        .take(bits_to_take)
+        .collect::<Vec<bool>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+pub(crate) fn constrain_bool<F: Field, CS: ConstraintSystem<F>>(
+    cs: &mut CS,
+    input: &[bool],
+) -> Result<Vec<Boolean>, SynthesisError> {
+    input
+        .iter()
+        .enumerate()
+        .map(|(j, b)| Boolean::alloc(cs.ns(|| format!("{}", j)), || Ok(b)))
+        .collect::<Result<Vec<_>, _>>()
+}
+
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
+    use algebra::{Field, Group};
+    use r1cs_core::ConstraintSystem;
+    use r1cs_std::groups::GroupGadget;
+
+    /// Allocates an array of group elements to a group gadget
+    pub fn alloc_vec<F: Field, G: Group, GG: GroupGadget<G, F>, CS: ConstraintSystem<F>>(
+        cs: &mut CS,
+        elements: &[G],
+    ) -> Vec<GG> {
+        elements
+            .iter()
+            .enumerate()
+            .map(|(i, element)| GG::alloc(&mut cs.ns(|| format!("{}", i)), || Ok(element)).unwrap())
+            .collect::<Vec<_>>()
+    }
+}

--- a/crates/bls-gadgets/src/utils.rs
+++ b/crates/bls-gadgets/src/utils.rs
@@ -30,7 +30,7 @@ pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
     bytes
 }
 
-/// If bytes is a little endian representation of a number, this returns the bits 
+/// If bytes is a little endian representation of a number, this returns the bits
 /// of the number in descending order
 pub fn bytes_to_bits(bytes: &[u8], bits_to_take: usize) -> Vec<bool> {
     let mut bits = vec![];
@@ -60,7 +60,6 @@ pub(crate) fn constrain_bool<F: Field, CS: ConstraintSystem<F>>(
         .map(|(j, b)| Boolean::alloc(cs.ns(|| format!("{}", j)), || Ok(b)))
         .collect::<Result<Vec<_>, _>>()
 }
-
 
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -12,7 +12,7 @@ use bls_crypto::{
     hashers::{Hasher, COMPOSITE_HASHER},
     Signature, SIG_DOMAIN,
 };
-use bls_gadgets::bytes_to_bits;
+use bls_gadgets::utils::bytes_to_bits;
 
 use groth16::{create_proof_no_zk, Parameters as Groth16Parameters, Proof as Groth16Proof};
 use r1cs_core::SynthesisError;

--- a/crates/epoch-snark/src/encoding.rs
+++ b/crates/epoch-snark/src/encoding.rs
@@ -3,7 +3,7 @@ use algebra::{
     FpParameters, PrimeField, ProjectiveCurve, ToBytes,
 };
 use bls_crypto::PublicKey;
-use bls_gadgets::bytes_to_bits;
+use bls_gadgets::utils::bytes_to_bits;
 use byteorder::{LittleEndian, WriteBytesExt};
 use thiserror::Error;
 
@@ -71,7 +71,7 @@ pub(crate) fn encode_u32(num: u32) -> Result<Vec<bool>, EncodingError> {
 mod test {
     use super::*;
     use algebra::{bls12_377::FqParameters, FpParameters};
-    use bls_gadgets::bits_to_bytes;
+    use bls_gadgets::utils::bits_to_bytes;
     use byteorder::{LittleEndian, WriteBytesExt};
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;

--- a/crates/epoch-snark/src/epoch_block.rs
+++ b/crates/epoch-snark/src/epoch_block.rs
@@ -5,7 +5,7 @@ use bls_crypto::{
     hash_to_curve::{try_and_increment::COMPOSITE_HASH_TO_G1, HashToCurve},
     PublicKey, Signature, OUT_DOMAIN, SIG_DOMAIN,
 };
-use bls_gadgets::{bits_to_bytes, bytes_to_bits};
+use bls_gadgets::utils::{bits_to_bytes, bytes_to_bits};
 
 /// A header as parsed after being fetched from the Celo Blockchain
 /// It contains information about the new epoch, as well as an aggregated

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -3,7 +3,7 @@ use algebra::{
     sw6::Fr,
     One, PairingEngine,
 };
-use bls_gadgets::{is_setup, HashToGroupGadget};
+use bls_gadgets::{utils::is_setup, HashToGroupGadget};
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use r1cs_std::{
     bls12_377::{G1Gadget, G2Gadget},

--- a/crates/epoch-snark/src/gadgets/hash_to_bits.rs
+++ b/crates/epoch-snark/src/gadgets/hash_to_bits.rs
@@ -89,7 +89,7 @@ mod tests {
     use crate::gadgets::pack;
     use algebra::{sw6::FrParameters as SW6FrParameters, Bls12_377};
     use bls_crypto::hashers::{DirectHasher, Hasher};
-    use bls_gadgets::{bits_to_bytes, bytes_to_bits};
+    use bls_gadgets::utils::{bits_to_bytes, bytes_to_bits};
     use groth16::{
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };

--- a/crates/epoch-snark/src/gadgets/pack.rs
+++ b/crates/epoch-snark/src/gadgets/pack.rs
@@ -1,5 +1,5 @@
 use algebra::{BigInteger, FpParameters, PrimeField};
-use bls_gadgets::is_setup;
+use bls_gadgets::utils::is_setup;
 use r1cs_core::SynthesisError;
 use r1cs_std::{fields::fp::FpGadget, prelude::*, Assignment};
 use tracing::{span, trace, Level};

--- a/crates/epoch-snark/src/gadgets/proof_of_compression.rs
+++ b/crates/epoch-snark/src/gadgets/proof_of_compression.rs
@@ -156,7 +156,7 @@ fn le_chunks(iter: &[Boolean], chunk_size: u32) -> Vec<Vec<Boolean>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bls_gadgets::bytes_to_bits;
+    use bls_gadgets::utils::bytes_to_bits;
     use rand::RngCore;
 
     use crate::epoch_block::hash_to_bits;

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -132,7 +132,7 @@ mod tests {
     use super::*;
     use crate::gadgets::to_fr;
     use algebra::UniformRand;
-    use bls_gadgets::test_helpers::alloc_vec;
+    use bls_gadgets::utils::test_helpers::alloc_vec;
     use r1cs_std::test_constraint_system::TestConstraintSystem;
 
     fn pubkeys<E: PairingEngine>(num: usize) -> Vec<E::G2Projective> {


### PR DESCRIPTION
Slight cleanup on the library's top level interface